### PR TITLE
Allow dart's custom [foo] link syntax contain multiple text elements.

### DIFF
--- a/lib/src/markdown/inline_parser.dart
+++ b/lib/src/markdown/inline_parser.dart
@@ -280,13 +280,13 @@ class LinkSyntax extends TagSyntax {
 
       // Only allow implicit links if the content is just text.
       // TODO(rnystrom): Do we want to relax this?
-      if (state.children.length != 1) return false;
-      if (state.children[0] is! Text) return false;
-
-      Text link = state.children[0];
-
+      if (state.children.any((child) => child is! Text)) return false;
+      // If there are multiple children, but they are all text, send the
+      // combined text to linkResolver.
+      var textToResolve = state.children.fold('',
+          (oldVal, child) => oldVal + child.text);
       // See if we have a resolver that will generate a link for us.
-      final node = linkResolver(link.text);
+      final node = linkResolver(textToResolve);
       if (node == null) return false;
 
       parser.addNode(node);

--- a/test/markdown_test.dart
+++ b/test/markdown_test.dart
@@ -882,11 +882,16 @@ void main() {
         <p>~=[,,_,,]:3</p>
         ''', inlineSyntaxes: nyanSyntax);
 
+    validate('dart custom links', 'links [are<foo>] awesome',
+      '<p>links <a>are&lt;foo></a> awesome</p>',
+      linkResolver: (text) => new Element.text('a', text.replaceAll('<',
+      '&lt;')));
+
     // TODO(amouravski): need more tests here for custom syntaxes, as some
     // things are not quite working properly. The regexps are sometime a little
     // too greedy, I think.
   });
-  
+
   group('Inline only', () {
     validate('simple line', '''
         This would normally create a paragraph.
@@ -957,7 +962,7 @@ String cleanUpLiteral(String text) {
 }
 
 validate(String description, String markdown, String html,
-         {bool verbose: false, inlineSyntaxes, linkResolver, 
+         {bool verbose: false, inlineSyntaxes, linkResolver,
           bool inlineOnly: false}) {
   test(description, () {
     markdown = cleanUpLiteral(markdown);


### PR DESCRIPTION
This change slightly relaxes the custom dart [foo] link syntax to allow multiple text elements (found the problem when working with Dart's documentation tool).

(Allows [foo<bar>] to be a link)
