### PR TITLE
Implement inlineOnly optional argument to markdownToHtml

### DIFF
--- a/lib/markdown.dart
+++ b/lib/markdown.dart
@@ -14,15 +14,20 @@ part 'src/markdown/inline_parser.dart';
 typedef Node Resolver(String name);
 
 /// Converts the given string of markdown to HTML.
-String markdownToHtml(String markdown, {inlineSyntaxes, linkResolver}) {
+String markdownToHtml(String markdown, {inlineSyntaxes, linkResolver, 
+                      bool inlineOnly: false}) {
   final document = new Document(inlineSyntaxes: inlineSyntaxes,
       linkResolver: linkResolver);
 
-  // Replace windows line endings with unix line endings, and split.
-  final lines = markdown.replaceAll('\r\n','\n').split('\n');
-  document.parseRefLinks(lines);
-  final blocks = document.parseLines(lines);
-  return renderToHtml(blocks);
+  if (inlineOnly) {
+    return renderToHtml(document.parseInline(markdown));
+  } else {
+    // Replace windows line endings with unix line endings, and split.
+    final lines = markdown.replaceAll('\r\n','\n').split('\n');
+    document.parseRefLinks(lines);
+    final blocks = document.parseLines(lines);
+    return renderToHtml(blocks);
+  }
 }
 
 /// Replaces `<`, `&`, and `>`, with their HTML entity equivalents.

--- a/test/markdown_test.dart
+++ b/test/markdown_test.dart
@@ -855,6 +855,46 @@ void main() {
     // things are not quite working properly. The regexps are sometime a little
     // too greedy, I think.
   });
+  
+  group('Inline only', () {
+    validate('simple line', '''
+        This would normally create a paragraph.
+        ''', '''
+        This would normally create a paragraph.
+        ''', inlineOnly: true);
+    validate('strong and em', '''
+        This would _normally_ create a **paragraph**.
+        ''', '''
+        This would <em>normally</em> create a <strong>paragraph</strong>.
+        ''', inlineOnly: true);
+    validate('link', '''
+        This [link](http://www.example.com/) will work normally.
+        ''', '''
+        This <a href="http://www.example.com/">link</a> will work normally.
+        ''', inlineOnly: true);
+    validate('references do not work', '''
+        [This][] shouldn't work, though.
+        ''', '''
+        [This][] shouldn't work, though.
+        ''', inlineOnly: true);
+    validate('less than and ampersand are escaped', '''
+        < &
+        ''', '''
+        &lt; &amp;
+        ''', inlineOnly: true);
+    validate('keeps newlines', '''
+        This paragraph
+        continues after a newline.
+        ''', '''
+        This paragraph
+        continues after a newline.
+        ''', inlineOnly: true);
+    validate('ignores block-level markdown syntax', '''
+        1. This will not be an <ol>.
+        ''', '''
+        1. This will not be an &lt;ol>.
+        ''', inlineOnly: true);
+  });
 }
 
 /**
@@ -886,13 +926,14 @@ String cleanUpLiteral(String text) {
 }
 
 validate(String description, String markdown, String html,
-         {bool verbose: false, inlineSyntaxes, linkResolver}) {
+         {bool verbose: false, inlineSyntaxes, linkResolver, 
+          bool inlineOnly: false}) {
   test(description, () {
     markdown = cleanUpLiteral(markdown);
     html = cleanUpLiteral(html);
 
     var result = markdownToHtml(markdown, inlineSyntaxes: inlineSyntaxes,
-        linkResolver: linkResolver);
+        linkResolver: linkResolver, inlineOnly: inlineOnly);
     var passed = compareOutput(html, result);
 
     if (!passed) {


### PR DESCRIPTION
I often need to markdown just one line of text. Sometimes, I know (and want) the output to be just one paragraph and nothing else. But I still want the comfort of markdown for its contents.

As another example, when providing the contents of a button (or other inline element) in markdown format, the &lt;p>&lt;/p> tags are not only not needed, but excessive and a pain to get rid of. More over, if the text of the inline element is, say, "-10 points", then markdownToHtml outputs an &lt;ul> element instead of &lt;p>, adding to the complexity.

My proposed change is adding a boolean option to `markdownToHtml` called `inlineOnly`. The code is then:

```
var html = markdownToHtml("Release the **Kraken**", inlineOnly: true);
```

There is no API change for standard use.
