### PR TITLE
Images Support

### DIFF
--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -2,7 +2,21 @@ library markdown.util;
 
 /// Replaces `<`, `&`, and `>`, with their HTML entity equivalents.
 String escapeHtml(String html) {
+  if (html == '' || html == null) return null;
   return html.replaceAll('&', '&amp;')
              .replaceAll('<', '&lt;')
              .replaceAll('>', '&gt;');
+}
+
+/// Removes null or empty values from [map].
+void cleanMap(Map map) {
+  map.keys
+    .where((e) => isNullOrEmpty(map[e]))
+    .toList()
+    .forEach(map.remove);
+}
+
+/// Returns true if an object is null or an empty string.
+bool isNullOrEmpty(object) {
+  return object == null || object == '';
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: markdown
-version: 0.5.1
+version: 0.6.0-dev
 author: Dart Team <misc@dartlang.org>
 description: A library for converting markdown to HTML.
 homepage: https://github.com/dpeek/dart-markdown

--- a/test/markdown_test.dart
+++ b/test/markdown_test.dart
@@ -862,6 +862,94 @@ void main() {
         ''');
   });
 
+  group('Inline Images', () {
+    validate('image','''
+        ![](http://foo.com/foo.png)
+        ''','''
+        <p>
+          <a href="http://foo.com/foo.png">
+            <img src="http://foo.com/foo.png"></img>
+          </a>
+        </p>
+        ''');
+
+    validate('alternate text','''
+        ![alternate text](http://foo.com/foo.png)
+        ''','''
+        <p>
+          <a href="http://foo.com/foo.png">
+            <img alt="alternate text" src="http://foo.com/foo.png"></img>
+          </a>
+        </p>
+        ''');
+
+    validate('title','''
+        ![](http://foo.com/foo.png "optional title")
+        ''','''
+        <p>
+          <a href="http://foo.com/foo.png" title="optional title">
+            <img src="http://foo.com/foo.png" title="optional title"></img>
+          </a>
+        </p>
+        ''');
+    validate('invalid alt text','''
+        ![`alt`](http://foo.com/foo.png)
+        ''','''
+        <p>
+          <a href="http://foo.com/foo.png">
+            <img src="http://foo.com/foo.png"></img>
+          </a>
+        </p>
+        ''');
+  });
+
+  group('Reference Images', () {
+    validate('image','''
+        ![][foo]
+        [foo]: http://foo.com/foo.png
+        ''','''
+        <p>
+          <a href="http://foo.com/foo.png">
+            <img src="http://foo.com/foo.png"></img>
+          </a>
+        </p>
+        ''');
+
+    validate('alternate text','''
+        ![alternate text][foo]
+        [foo]: http://foo.com/foo.png
+        ''','''
+        <p>
+          <a href="http://foo.com/foo.png">
+            <img alt="alternate text" src="http://foo.com/foo.png"></img>
+          </a>
+        </p>
+        ''');
+
+    validate('title','''
+        ![][foo]
+        [foo]: http://foo.com/foo.png "optional title"
+        ''','''
+        <p>
+          <a href="http://foo.com/foo.png" title="optional title">
+            <img src="http://foo.com/foo.png" title="optional title"></img>
+          </a>
+        </p>
+        ''');
+
+    validate('invalid alt text','''
+        ![`alt`][foo]
+        [foo]: http://foo.com/foo.png "optional title"
+        ''','''
+        <p>
+          <a href="http://foo.com/foo.png" title="optional title">
+            <img src="http://foo.com/foo.png" title="optional title"></img>
+          </a>
+        </p>
+        ''');
+
+  });
+
   group('Resolver', () {
     var nyanResolver = (text) => new Text('~=[,,_${text}_,,]:3');
     validate('simple resolver', '''


### PR DESCRIPTION
Add support for images declared with the following syntax:

``` no-highlight
![alternate text](url "optional title")
Images can also use reference style links.
![alternate text][url reference]

// [url reference]: url "optional title"
```

Many dart projects use this syntax to display the CI status in the documentation but it doesn't display because this library doesn't support this syntax.
