### PR TITLE
Fix type issues, lock down types (breaking changes), bumped to 0.7.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: markdown
-version: 0.6.0+1
+version: 0.7.0
 author: Dart Team <misc@dartlang.org>
 description: A library for converting markdown to HTML.
 homepage: https://github.com/dpeek/dart-markdown


### PR DESCRIPTION
Fixes dpeek/dart-markdown/#15

Hiding a few things, make other things final, so this is a breaking change.

All tests pass in checked mode.
