### PR TITLE
Adding ids to headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 * Inline HTML syntax support; This is also considered an extension (#18).
 * The text `[foo] (bar)` now parses as an inline link (#53).
 * The text `[foo]()` now renders as an inline link.
+* Header identifier support in the HeaderWithIdSyntax and
+  SetextHeaderWithIdSyntax extensions.
 
 ## 0.8.0
 

--- a/README.md
+++ b/README.md
@@ -25,12 +25,17 @@ specifying an Array of extension syntaxes in the `blockSyntaxes` or
 The currently supported inline extension syntaxes are:
 
 * `new InlineHtmlSyntax()` - approximately CommonMark's
-  [definition](http://spec.commonmark.org/0.22/#raw-html) of "Raw HTML".
+  [definition][commonmark-raw-html] of "Raw HTML".
 
 The currently supported block extension syntaxes are:
 
 * `const FencedCodeBlockSyntax()` - Code blocks familiar to Pandoc and PHP
   Markdown Extra users.
+* `const HeaderWithIdSyntax()` - ATX-style headers have generated IDs, for link
+  anchors (akin to Pandoc's [`auto_identifiers`][pandoc-auto_identifiers]).
+* `const SetextHeaderWithIdSyntax()` - Setext-style headers have generated IDs
+  for link anchors (akin to Pandoc's
+  [`auto_identifiers`][pandoc-auto_identifiers]).
 
 For example:
 
@@ -75,3 +80,5 @@ void main() {
 
 [Perl Markdown]: http://daringfireball.net/projects/markdown/
 [CommonMark]: http://commonmark.org/
+[commonMark-raw-html]: http://spec.commonmark.org/0.22/#raw-html
+[pandoc-auto_identifiers]: http://pandoc.org/README.html#extension-auto_identifiers

--- a/lib/src/ast.dart
+++ b/lib/src/ast.dart
@@ -17,6 +17,7 @@ class Element implements Node {
   final String tag;
   final List<Node> children;
   final Map<String, String> attributes;
+  String generatedId;
 
   Element(this.tag, this.children) : attributes = <String, String>{};
 

--- a/test/extensions/headers_with_ids.unit
+++ b/test/extensions/headers_with_ids.unit
@@ -1,0 +1,27 @@
+>>> simple header
+# header
+
+<<<
+<h1 id="header">header</h1>
+>>> header that starts with garbage
+## 2. header again
+
+<<<
+<h2 id="header-again">2. header again</h2>
+>>> header with inline syntaxes
+### headers **rock** `etc.`
+
+<<<
+<h3 id="headers-rock-etc">headers <strong>rock</strong> <code>etc.</code></h3>
+>>> non-unique headers
+# header
+
+## header
+
+<<<
+<h1 id="header">header</h1>
+<h2 id="header-2">header</h2>
+>>> header starts with inline syntax
+# *headers* etc.
+<<<
+<h1 id="headers-etc"><em>headers</em> etc.</h1>

--- a/test/extensions/setext_headers_with_ids.unit
+++ b/test/extensions/setext_headers_with_ids.unit
@@ -1,0 +1,18 @@
+>>> h1
+text
+===
+
+<<<
+<h1 id="text">text</h1>
+>>> h2
+text
+---
+
+<<<
+<h2 id="text">text</h2>
+>>> header with inline syntax
+header *emphasised*
+===
+
+<<<
+<h1 id="header-emphasised">header <em>emphasised</em></h1>

--- a/test/markdown_test.dart
+++ b/test/markdown_test.dart
@@ -105,4 +105,10 @@ nyan''', '''<p>~=[,,_,,]:3</p>
 
   testFile('extensions/inline_html.unit',
       inlineSyntaxes: [new InlineHtmlSyntax()]);
+
+  testFile('extensions/headers_with_ids.unit',
+      blockSyntaxes: [const HeaderWithIdSyntax()]);
+
+  testFile('extensions/setext_headers_with_ids.unit',
+      blockSyntaxes: [const SetextHeaderWithIdSyntax()]);
 }


### PR DESCRIPTION
I changed the (Setext)HeaderSyntax to generate an id for all headers generated, so that they can be deep-linked. This deep-linking can then also be used within a document using something like \[#this](text).