### PR TITLE
Apply hljs style to code block, not pre element

### DIFF
--- a/lib/src/block_parser.dart
+++ b/lib/src/block_parser.dart
@@ -289,10 +289,11 @@ class FencedCodeBlockSyntax extends BlockSyntax {
     // Escape the code.
     final escaped = escapeHtml(childLines.join('\n'));
 
-    var element = new Element('pre', [new Element.text('code', escaped)]);
+    var codeElement = new Element.text('code', escaped);
     if (syntax != '') {
-      element.attributes['class'] = syntax;
+      codeElement.attributes['class'] = syntax;
     }
+    var element = new Element('pre', [codeElement]);
     return element;
   }
 }


### PR DESCRIPTION
The [highlighjs usage documentation]() encourages the `code` element to contain the css class for the language:

```
<pre><code class="html">...</code></pre>
```

This changes the converter to use that style instead of applying it to the `pre` element.

@dpeek 