### PR TITLE
Add a simple binary Dart script

### DIFF
--- a/bin/markdown.dart
+++ b/bin/markdown.dart
@@ -1,0 +1,22 @@
+import 'dart:io';
+
+import 'package:markdown/markdown.dart';
+
+void main(List<String> args) async {
+  if (args.length > 1) {
+    print('Usage: markdown.dart [file]');
+    exit(1);
+  }
+
+  if (args.length == 1) {
+    // Read argument as a file path.
+    print(markdownToHtml(new File(args[0]).readAsStringSync()));
+    exit(0);
+  }
+
+  // Read from stdin.
+  var buffer = new StringBuffer();
+  var line;
+  while ((line = stdin.readLineSync()) != null) buffer.writeln(line);
+  print(markdownToHtml(buffer.toString()));
+}


### PR DESCRIPTION
I use this library often enough that I'd love to just be able to run it from the command line.

This is a crazy simple script that either reads an argument as a file, or reads from stdin, and spits HTML out to stdout.

I have no intention to add more features to this, but there will probably be requests :stuck_out_tongue_closed_eyes: 