### PR TITLE
Fix some bugs in the CodeSyntax implementation

### DIFF
--- a/lib/src/inline_parser.dart
+++ b/lib/src/inline_parser.dart
@@ -50,10 +50,7 @@ class InlineParser {
     // TODO(rnystrom): Underscores in the middle of a word should not be
     // parsed as emphasis like_in_this.
     new TagSyntax(r'_', tag: 'em'),
-    // Parse inline code within double backticks: "``code``".
-    new CodeSyntax(r'``\s?((?:.|\n)*?)\s?``'),
-    // Parse inline code within backticks: "`code`".
-    new CodeSyntax(r'`([^`]*)`')
+    new CodeSyntax(),
     // We will add the LinkSyntax once we know about the specific link resolver.
   ];
 
@@ -172,6 +169,9 @@ abstract class InlineSyntax {
 
   InlineSyntax(String pattern) : pattern = new RegExp(pattern, multiLine: true);
 
+  /// Try to match at the parser's current position.
+  ///
+  /// Returns whether or not the pattern successfully matched.
   bool tryMatch(InlineParser parser) {
     var startMatch = pattern.matchAsPrefix(parser.source, parser.pos);
     if (startMatch != null) {
@@ -375,10 +375,41 @@ class ImageLinkSyntax extends LinkSyntax {
 
 /// Matches backtick-enclosed inline code blocks.
 class CodeSyntax extends InlineSyntax {
-  CodeSyntax(String pattern) : super(pattern);
+  // This pattern matches:
+  //
+  // * a string of backticks (not followed by any more), followed by
+  // * a non-greedy string of anying, including newlines, ending with anything
+  //   except a backtick, followed by
+  // * a string of backticks the same length as the first, not followed by any
+  //   more.
+  //
+  // This conforms to the delimiters of inline code, both in Markdown.pl, and
+  // CommonMark.
+  static String _pattern = r'(`+(?!`))((?:.|\n)*?[^`])\1(?!`)';
+
+  CodeSyntax() : super(_pattern);
+
+  bool tryMatch(InlineParser parser) {
+    if (parser.pos > 0 && parser.source[parser.pos-1] == '`') {
+      // Not really a match! We can't just sneak past one backtick to try the
+      // next character. An example of this situation would be:
+      //
+      //     before ``` and `` after.
+      //             ^--parser.pos
+      return false;
+    }
+
+    var match = pattern.matchAsPrefix(parser.source, parser.pos);
+    if (match == null) {
+      return false;
+    }
+    parser.writeText();
+    if (onMatch(parser, match)) parser.consume(match[0].length);
+    return true;
+  }
 
   bool onMatch(InlineParser parser, Match match) {
-    parser.addNode(new Element.text('code', escapeHtml(match[1])));
+    parser.addNode(new Element.text('code', escapeHtml(match[2].trim())));
     return true;
   }
 }

--- a/test/original/inline_code.unit
+++ b/test/original/inline_code.unit
@@ -3,6 +3,11 @@ before `source` after
 
 <<<
 <p>before <code>source</code> after</p>
+>>> single characters
+before `x` and `_` after
+
+<<<
+<p>before <code>x</code> and <code>_</code> after</p>
 >>> unmatched backtick
 before ` after
 
@@ -25,6 +30,11 @@ before ``source`` after
 
 <<<
 <p>before <code>source</code> after</p>
+>>> even more backticks
+before ````source with ``` and```` after
+
+<<<
+<p>before <code>source with ``` and</code> after</p>
 >>> double backticks
 before ``can `contain` backticks`` after
 
@@ -35,6 +45,13 @@ before `` `tick` `` after
 
 <<<
 <p>before <code>`tick`</code> after</p>
+>>> multiline single backticks with spaces
+before `in tick
+another` after
+
+<<<
+<p>before <code>in tick
+another</code> after</p>
 >>> multiline double backticks with spaces
 before ``in `tick`
 another`` after
@@ -57,3 +74,13 @@ before `*b* _c_` after
 
 <<<
 <p>'*' <code>&lt;em&gt;</code></p>
+>>> leave unmatched backticks when first are too long
+before ``` tick `` after
+
+<<<
+<p>before ``` tick `` after</p>
+>>> leave unmatched backticks when first are too short
+before `` tick ``` after
+
+<<<
+<p>before `` tick ``` after</p>


### PR DESCRIPTION
This fixes some bugs in the CodeSyntax implementation. Namely:

1. Inline code delimited with single backticks should allow inner newlines.
2. Whitespace just inside backticks should be swallowed (not just inside double-backticks):

   ``before ` text ` after`` should render to `before <code>text</code> after`.
3. Numbers of backticks greater than 2 should be allowed.
4. Inline codes are not allowed to be adjacent to each other:

  ```before `foo `` bar` after``` should render to `before <code>foo `` bar</code> after`.

These are according to the rules of [CommonMark](http://spec.commonmark.org/0.22/#code-spans), and the canonical Markdown.pl implementation.