### PR TITLE
Fix [foo] (bar) bug, and [foo]() bug.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 * **Breaking:** Fenced code blocks are now considered an extension, as
   they are not part of Markdown.pl.
 * Inline HTML syntax supported. This is also considered an extension (#18).
+* The text `[foo] (bar)` now parses as an inline link (#53).
+* The text `[foo]()` now renders as an inline link.
 
 ## 0.8.0
 

--- a/lib/src/inline_parser.dart
+++ b/lib/src/inline_parser.dart
@@ -249,17 +249,17 @@ class TagSyntax extends InlineSyntax {
   }
 }
 
-/// Matches inline links like `[blah] [id]` and `[blah] (url)`.
+/// Matches inline links like `[blah][id]` and `[blah](url)`.
 class LinkSyntax extends TagSyntax {
   final Resolver linkResolver;
 
-  /// The regex for the end of a link needs to handle both reference style and
-  /// inline styles as well as optional titles for inline links. To make that
+  /// The regex for the end of a link needs to handle both reference-style and
+  /// inline-style links as well as optional titles for inline links. To make that
   /// a bit more palatable, this breaks it into pieces.
   static get linkPattern {
-    var refLink = r'\s?\[([^\]]*)\]'; // "[id]" reflink id.
+    var refLink = r'\[([^\]]*)\]'; // "[id]" reflink id.
     var title = r'(?:[ ]*"([^"]+)"|)'; // Optional title in quotes.
-    var inlineLink = '\\s?\\(([^ )]+)$title\\)'; // "(url "title")" link.
+    var inlineLink = '\\(([^ )]*)$title\\)'; // "(url "title")" link.
     return '\](?:($refLink|$inlineLink)|)';
 
     // The groups matched by this are:
@@ -275,7 +275,7 @@ class LinkSyntax extends TagSyntax {
 
   Node createNode(InlineParser parser, Match match, TagState state) {
     // If we didn't match refLink or inlineLink, then it means there was
-    // nothing after the first square bracket, so it isn't a normal markdown
+    // nothing after the first square bracket, so it isn't a normal Markdown
     // link at all. Instead, we allow users of the library to specify a special
     // resolver function ([linkResolver]) that may choose to handle
     // this. Otherwise, it's just treated as plain text.
@@ -311,12 +311,12 @@ class LinkSyntax extends TagSyntax {
   }
 
   Link getLink(InlineParser parser, Match match, TagState state) {
-    if (match[3] != null && match[3] != '') {
+    if (match[3] != null) {
       // Inline link like [foo](url).
       var url = match[3];
       var title = match[4];
 
-      // For whatever reason, markdown allows angle-bracketed URLs here.
+      // For whatever reason, Markdown allows angle-bracketed URLs here.
       if (url.startsWith('<') && url.endsWith('>')) {
         url = url.substring(1, url.length - 1);
       }
@@ -324,7 +324,7 @@ class LinkSyntax extends TagSyntax {
       return new Link(null, url, title);
     } else {
       var id;
-      // Reference link like [foo] [bar].
+      // Reference link like [foo][bar].
       if (match[2] == '') {
         // The id is empty ("[]") so infer it from the contents.
         id = parser.source.substring(state.startPos + 1, parser.pos);

--- a/test/original/inline_links.unit
+++ b/test/original/inline_links.unit
@@ -4,7 +4,7 @@ links [are](http://foo.com "woo") awesome
 <<<
 <p>links <a href="http://foo.com" title="woo">are</a> awesome</p>
 >>> no title
-links [are] (http://foo.com) awesome
+links [are](http://foo.com) awesome
 
 <<<
 <p>links <a href="http://foo.com">are</a> awesome</p>
@@ -13,3 +13,18 @@ links [*are*](http://foo.com) awesome
 
 <<<
 <p>links <a href="http://foo.com"><em>are</em></a> awesome</p>
+>>> no URL
+links [are]() awesome
+
+<<<
+<p>links <a href="">are</a> awesome</p>
+>>> URL wrapped in angle brackets
+links [are](<http://example.com>) awesome
+
+<<<
+<p>links <a href="http://example.com">are</a> awesome</p>
+>>> not a real link
+links [are] (http://foo.com) awesome
+
+<<<
+<p>links [are] (http://foo.com) awesome</p>

--- a/test/original/reference_links.unit
+++ b/test/original/reference_links.unit
@@ -1,26 +1,26 @@
 >>> double quotes for title
-links [are] [a] awesome
+links [are][a] awesome
 
 [a]: http://foo.com "woo"
 
 <<<
 <p>links <a href="http://foo.com" title="woo">are</a> awesome</p>
 >>> single quoted title
-links [are] [a] awesome
+links [are][a] awesome
 
 [a]: http://foo.com 'woo'
 
 <<<
 <p>links <a href="http://foo.com" title="woo">are</a> awesome</p>
 >>> parentheses for title
-links [are] [a] awesome
+links [are][a] awesome
 
 [a]: http://foo.com (woo)
 
 <<<
 <p>links <a href="http://foo.com" title="woo">are</a> awesome</p>
 >>> no title
-links [are] [a] awesome
+links [are][a] awesome
 
 [a]: http://foo.com
 
@@ -32,7 +32,7 @@ links [are] [a] awesome
 <<<
 <p>[not] [known]</p>
 >>> can style link contents
-links [*are*] [a] awesome
+links [*are*][a] awesome
 
 [a]: http://foo.com
 


### PR DESCRIPTION
Fixes #53 

This also adds a little more conformance, making `[foo]()` render to a link.