### PR TITLE
Extension Sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 ## 0.9.0
 
 * Formalize an API for Markdown extensions (#43).
-* **Breaking:** Fenced code blocks are now considered an extension, as
-  they are not part of Markdown.pl.
-* Inline HTML syntax supported. This is also considered an extension (#18).
+* Introduce ExtensionSets. FencedCodeBlock is considered an extension, but
+  existing usage of `markdownToHtml()` and `new Document()` will use the
+  default extension set, which is `ExtensionSet.commonMark`, which includes
+  FencedCodeBlock.
+* Inline HTML syntax support; This is also considered an extension (#18).
 * The text `[foo] (bar)` now parses as an inline link (#53).
 * The text `[foo]()` now renders as an inline link.
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,11 @@ void main() {
 Syntax extensions
 -----------------
 
-A few Markdown extensions are supported. They are all disabled by default, and
-can be enabled by specifying an Array of extension syntaxes in the `blockSyntaxes` or `inlineSyntaxes`
-argument of `markdownToHtml`.
+A few Markdown extensions, beyond what was specified in the original
+[Perl Markdown][] implementation, are supported. By default, the ones supported
+in [CommonMark] are enabled. Any individual extension can be enabled by
+specifying an Array of extension syntaxes in the `blockSyntaxes` or
+`inlineSyntaxes` argument of `markdownToHtml`.
 
 The currently supported inline extension syntaxes are:
 
@@ -42,6 +44,21 @@ void main() {
 }
 ```
 
+### Extension Sets
+
+To make extension management easy, you can also just specify an extension set.
+Both `markdownToHtml()` and `new Document()` accept an `extensionSet` named
+parameter. Right now there are two extension sets:
+
+* `ExtensionSet.none` includes no extensions. With no extensions, Markdown
+  documents will be parsed closely to how they might be parsed by the original
+  [Perl Markdown][] implementation.
+* `ExtensionSet.commonMark` includes two extensions so far, which bring this
+  package's Markdown parsing closer to what is found in the [CommonMark] spec:
+
+  * `new InlineHtmlSyntax()`
+  * `const FencedCodeBlockSyntax()`
+
 ### Custom syntax extensions
 
 You can create and use your own syntaxes.
@@ -55,3 +72,6 @@ void main() {
   //=> <p>~=[,,_,,]:3</p>
 }
 ```
+
+[Perl Markdown]: http://daringfireball.net/projects/markdown/
+[CommonMark]: http://commonmark.org/

--- a/lib/markdown.dart
+++ b/lib/markdown.dart
@@ -8,5 +8,6 @@ library markdown;
 export 'src/ast.dart';
 export 'src/block_parser.dart';
 export 'src/document.dart';
+export 'src/extension_set.dart';
 export 'src/html_renderer.dart';
 export 'src/inline_parser.dart';

--- a/lib/src/document.dart
+++ b/lib/src/document.dart
@@ -2,22 +2,30 @@ library markdown.src.document;
 
 import 'ast.dart';
 import 'block_parser.dart';
+import 'extension_set.dart';
 import 'inline_parser.dart';
 
 /// Maintains the context needed to parse a Markdown document.
 class Document {
-  final Map<String, Link> refLinks;
+  final Map<String, Link> refLinks = {};
   List<BlockSyntax> blockSyntaxes;
   List<InlineSyntax> inlineSyntaxes;
+  ExtensionSet extensionSet;
   Resolver linkResolver;
   Resolver imageLinkResolver;
 
   Document(
-      {this.blockSyntaxes: const [],
-      this.inlineSyntaxes: const [],
+      {this.blockSyntaxes,
+      this.inlineSyntaxes,
+      extensionSet,
       this.linkResolver,
-      this.imageLinkResolver})
-      : refLinks = <String, Link>{};
+      this.imageLinkResolver}) {
+    blockSyntaxes ??= [];
+    inlineSyntaxes ??= [];
+    extensionSet ??= ExtensionSet.commonMark;
+    blockSyntaxes.addAll(extensionSet.blockSyntaxes);
+    inlineSyntaxes.addAll(extensionSet.inlineSyntaxes);
+  }
 
   parseRefLinks(List<String> lines) {
     // This is a hideous regex. It matches:

--- a/lib/src/extension_set.dart
+++ b/lib/src/extension_set.dart
@@ -1,0 +1,14 @@
+import 'block_parser.dart';
+import 'inline_parser.dart';
+
+class ExtensionSet {
+  static ExtensionSet none = new ExtensionSet._([], []);
+
+  static ExtensionSet commonMark = new ExtensionSet._(
+      [const FencedCodeBlockSyntax()], [new InlineHtmlSyntax()]);
+
+  final List blockSyntaxes;
+  final List inlineSyntaxes;
+
+  ExtensionSet._(this.blockSyntaxes, this.inlineSyntaxes);
+}

--- a/lib/src/html_renderer.dart
+++ b/lib/src/html_renderer.dart
@@ -6,20 +6,23 @@ library markdown.src.html_renderer;
 
 import 'ast.dart';
 import 'document.dart';
+import 'extension_set.dart';
 import 'inline_parser.dart';
 
 /// Converts the given string of markdown to HTML.
 String markdownToHtml(String markdown,
-    {List<BlockSyntax> blockSyntaxes: const [],
-    List<InlineSyntax> inlineSyntaxes: const [],
+    {List<BlockSyntax> blockSyntaxes,
+    List<InlineSyntax> inlineSyntaxes,
+    ExtensionSet extensionSet,
     Resolver linkResolver,
     Resolver imageLinkResolver,
     bool inlineOnly: false}) {
   var document = new Document(
       blockSyntaxes: blockSyntaxes,
       inlineSyntaxes: inlineSyntaxes,
-      imageLinkResolver: imageLinkResolver,
-      linkResolver: linkResolver);
+      extensionSet: extensionSet,
+      linkResolver: linkResolver,
+      imageLinkResolver: imageLinkResolver);
 
   if (inlineOnly) return renderToHtml(document.parseInline(markdown));
 

--- a/lib/src/inline_parser.dart
+++ b/lib/src/inline_parser.dart
@@ -209,7 +209,7 @@ class TextSyntax extends InlineSyntax {
 /// TODO(srawlins): improve accuracy while ensuring performance, once
 /// Markdown benchmarking is more mature.
 class InlineHtmlSyntax extends TextSyntax {
-  InlineHtmlSyntax() : super(r'</?[A-Za-z][^>]*>');
+  InlineHtmlSyntax() : super(r'<[/!?]?[A-Za-z][A-Za-z0-9-]*(?: [^>]*)?>');
 }
 
 /// Matches autolinks like `<http://foo.com>`.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ author: Dart Team <misc@dartlang.org>
 description: A library for converting markdown to HTML.
 homepage: https://github.com/dart-lang/markdown
 environment:
-  sdk: '>=1.8.0 <2.0.0'
+  sdk: '>=1.12.0 <2.0.0'
 dev_dependencies:
   path: '^1.3.1'
   test: '^0.12.4+1'

--- a/test/markdown_test.dart
+++ b/test/markdown_test.dart
@@ -96,7 +96,7 @@ nyan''', '''<p>~=[,,_,,]:3</p>
         1. This will not be an <ol>.
         ''',
         '''
-        1. This will not be an &lt;ol>.
+        1. This will not be an <ol>.
         ''', inlineOnly: true);
   });
 

--- a/test/util.dart
+++ b/test/util.dart
@@ -32,8 +32,8 @@ String get _testDir => p.dirname(currentMirrorSystem()
       .path);
 
 void testFile(String file,
-    {List<BlockSyntax> blockSyntaxes: const [],
-    List<InlineSyntax> inlineSyntaxes: const []}) =>
+    {List<BlockSyntax> blockSyntaxes,
+    List<InlineSyntax> inlineSyntaxes}) =>
   testUnitFile(
       file,
       new File(p.join(_testDir, file)),
@@ -43,8 +43,8 @@ void testFile(String file,
 void testUnitFile(
     String directory,
     File entry,
-    {List<BlockSyntax> blockSyntaxes: const [],
-    List<InlineSyntax> inlineSyntaxes: const []}) {
+    {List<BlockSyntax> blockSyntaxes,
+    List<InlineSyntax> inlineSyntaxes}) {
   group('$directory ${p.basename(entry.path)}', () {
     var lines = entry.readAsLinesSync();
 
@@ -91,8 +91,8 @@ void validateCore(
     String description,
     String markdown,
     String html,
-    {List<BlockSyntax> blockSyntaxes: const [],
-    List<InlineSyntax> inlineSyntaxes: const [],
+    {List<BlockSyntax> blockSyntaxes,
+    List<InlineSyntax> inlineSyntaxes,
     Resolver linkResolver,
     Resolver imageLinkResolver,
     bool inlineOnly: false}) {


### PR DESCRIPTION
We should support CommonMark by default.

This does that, which means that calling `markdownToHtml()` as before will keep the fenced code blocks, which good for things like, all of the READMEs and dartdoc comments that are currently using fenced code blocks.