### PR TITLE
Prevent duplicate syntaxes from being added to a document

### DIFF
--- a/lib/src/document.dart
+++ b/lib/src/document.dart
@@ -8,23 +8,25 @@ import 'inline_parser.dart';
 /// Maintains the context needed to parse a Markdown document.
 class Document {
   final Map<String, Link> refLinks = {};
-  List<BlockSyntax> blockSyntaxes;
-  List<InlineSyntax> inlineSyntaxes;
+  Iterable<BlockSyntax> blockSyntaxes;
+  Iterable<InlineSyntax> inlineSyntaxes;
   ExtensionSet extensionSet;
   Resolver linkResolver;
   Resolver imageLinkResolver;
 
   Document(
-      {this.blockSyntaxes,
-      this.inlineSyntaxes,
-      extensionSet,
+      {Iterable<BlockSyntax> blockSyntaxes,
+      Iterable<InlineSyntax> inlineSyntaxes,
+      ExtensionSet extensionSet,
       this.linkResolver,
       this.imageLinkResolver}) {
-    blockSyntaxes ??= [];
-    inlineSyntaxes ??= [];
     extensionSet ??= ExtensionSet.commonMark;
-    blockSyntaxes.addAll(extensionSet.blockSyntaxes);
-    inlineSyntaxes.addAll(extensionSet.inlineSyntaxes);
+    this.blockSyntaxes = new Set()
+      ..addAll(blockSyntaxes ?? [])
+      ..addAll(extensionSet.blockSyntaxes);
+    this.inlineSyntaxes = new Set()
+      ..addAll(inlineSyntaxes ?? [])
+      ..addAll(extensionSet.inlineSyntaxes);
   }
 
   parseRefLinks(List<String> lines) {

--- a/lib/src/html_renderer.dart
+++ b/lib/src/html_renderer.dart
@@ -11,8 +11,8 @@ import 'inline_parser.dart';
 
 /// Converts the given string of markdown to HTML.
 String markdownToHtml(String markdown,
-    {List<BlockSyntax> blockSyntaxes,
-    List<InlineSyntax> inlineSyntaxes,
+    {Iterable<BlockSyntax> blockSyntaxes,
+    Iterable<InlineSyntax> inlineSyntaxes,
     ExtensionSet extensionSet,
     Resolver linkResolver,
     Resolver imageLinkResolver,

--- a/test/util.dart
+++ b/test/util.dart
@@ -26,25 +26,18 @@ void testDirectory(String name) {
 
 // Locate the "test" directory. Use mirrors so that this works with the test
 // package, which loads this suite into an isolate.
-String get _testDir => p.dirname(currentMirrorSystem()
-      .findLibrary(#markdown.test.util)
-      .uri
-      .path);
+String get _testDir =>
+    p.dirname(currentMirrorSystem().findLibrary(#markdown.test.util).uri.path);
 
 void testFile(String file,
-    {List<BlockSyntax> blockSyntaxes,
-    List<InlineSyntax> inlineSyntaxes}) =>
-  testUnitFile(
-      file,
-      new File(p.join(_testDir, file)),
-      blockSyntaxes: blockSyntaxes,
-      inlineSyntaxes: inlineSyntaxes);
+        {Iterable<BlockSyntax> blockSyntaxes,
+        Iterable<InlineSyntax> inlineSyntaxes}) =>
+    testUnitFile(file, new File(p.join(_testDir, file)),
+        blockSyntaxes: blockSyntaxes, inlineSyntaxes: inlineSyntaxes);
 
-void testUnitFile(
-    String directory,
-    File entry,
-    {List<BlockSyntax> blockSyntaxes,
-    List<InlineSyntax> inlineSyntaxes}) {
+void testUnitFile(String directory, File entry,
+    {Iterable<BlockSyntax> blockSyntaxes,
+    Iterable<InlineSyntax> inlineSyntaxes}) {
   group('$directory ${p.basename(entry.path)}', () {
     var lines = entry.readAsLinesSync();
 
@@ -76,23 +69,15 @@ void testUnitFile(
         expectedOutput += lines[i] + "\n";
       }
 
-      validateCore(
-          description,
-          input,
-          expectedOutput,
-          blockSyntaxes: blockSyntaxes,
-          inlineSyntaxes: inlineSyntaxes
-          );
+      validateCore(description, input, expectedOutput,
+          blockSyntaxes: blockSyntaxes, inlineSyntaxes: inlineSyntaxes);
     }
   });
 }
 
-void validateCore(
-    String description,
-    String markdown,
-    String html,
-    {List<BlockSyntax> blockSyntaxes,
-    List<InlineSyntax> inlineSyntaxes,
+void validateCore(String description, String markdown, String html,
+    {Iterable<BlockSyntax> blockSyntaxes,
+    Iterable<InlineSyntax> inlineSyntaxes,
     Resolver linkResolver,
     Resolver imageLinkResolver,
     bool inlineOnly: false}) {


### PR DESCRIPTION
This is to address @munificent's [comment](https://github.com/dart-lang/markdown/pull/55#discussion_r40248140) on the Extension Sets pull request.

I thought it warranted a full review. `test/util.dart` is mostly changed because I ran `dartfmt` over it.