### PR TITLE
Fixing #30 and #60 by adding hard line break

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   SetextHeaderWithIdSyntax extensions.
 * Implement backslash-escaping so that Markdown syntax can be escaped, such as
   `[foo]\(bar) ==> <p>[foo](bar)</p>`.
+* Support for hard line breaks with either `\\\n` or `  \n` (#30, #60).
 * New public method for BlockParser: `peek(int linesAhead)`, meant for use in
   subclasses.
 * New public members for ListSyntax: `blocksInList` and `determineBlockItems()`,

--- a/lib/src/inline_parser.dart
+++ b/lib/src/inline_parser.dart
@@ -23,7 +23,7 @@ class InlineParser {
 
     // TODO(amouravski): this regex will glom up any custom syntaxes unless
     // they're at the beginning.
-    new TextSyntax(r'\s*[A-Za-z0-9]+'),
+    new TextSyntax(r'[ \tA-Za-z0-9]*[A-Za-z0-9]'),
 
     // The real syntaxes.
     new AutolinkSyntax(),
@@ -42,6 +42,10 @@ class InlineParser {
     new TextSyntax(r'&', sub: '&amp;'),
     // Encode "<". (Why not encode ">" too? Gruber is toying with us.)
     new TextSyntax(r'<', sub: '&lt;'),
+    // Escaped newlines become hard line breaks.
+    new TextSyntax(r'\\\n', sub: '<br />\n'),
+    // Two or more spaces at the end of a line become hard line breaks.
+    new TextSyntax(r'  +\n', sub: '<br />\n'),
     // Parse "**strong**" tags.
     new TagSyntax(r'\*\*', tag: 'strong'),
     // Parse "__strong__" tags.

--- a/test/original/hard_line_breaks.unit
+++ b/test/original/hard_line_breaks.unit
@@ -1,0 +1,42 @@
+>>> hard line break in a paragraph, using backslash
+First line.\
+Second line.
+
+<<<
+<p>First line.<br />
+Second line.</p>
+>>> within emphasis, using backslash
+*Emphasised\
+text.*
+
+<<<
+<p><em>Emphasised<br />
+text.</em></p>
+>>> no escape within code, using backslash
+`Some\
+code`.
+
+<<<
+<p><code>Some\
+code</code>.</p>
+>>> hard line break in a paragraph, using trailing spaces
+First line.  
+Second line.
+
+<<<
+<p>First line.<br />
+Second line.</p>
+>>> within emphasis, using trailing spaces
+*Emphasised  
+text.*
+
+<<<
+<p><em>Emphasised<br />
+text.</em></p>
+>>> no escape within code, using trailing spaces
+`Some  
+code`.
+
+<<<
+<p><code>Some  
+code</code>.</p>


### PR DESCRIPTION
The first regex change on inline_parser.dart:26 makes Markdown faster, while allowing the `r'  +\n'` to _not_ be the first TextSyntax.

Super oddly enough (to me), `\s*` was faster than`[ \t]*`, so I made the regex match multiple words in a row, separated by spaces or tabs, which makes it much faster again. So this PR doesn't slow down Markdown. Instead, it changes `benchmark.markdown` to go from 5.68 ms to 5.12 ms (9.9% faster).