### PR TITLE
Fix over-eager word syntax

### DIFF
--- a/lib/src/document.dart
+++ b/lib/src/document.dart
@@ -20,13 +20,13 @@ class Document {
       ExtensionSet extensionSet,
       this.linkResolver,
       this.imageLinkResolver}) {
-    extensionSet ??= ExtensionSet.commonMark;
+    this.extensionSet = extensionSet ?? ExtensionSet.commonMark;
     this.blockSyntaxes = new Set()
       ..addAll(blockSyntaxes ?? [])
-      ..addAll(extensionSet.blockSyntaxes);
+      ..addAll(this.extensionSet.blockSyntaxes);
     this.inlineSyntaxes = new Set()
       ..addAll(inlineSyntaxes ?? [])
-      ..addAll(extensionSet.inlineSyntaxes);
+      ..addAll(this.extensionSet.inlineSyntaxes);
   }
 
   /// Parses [lines] for reference links, adding them to [refLinks] and


### PR DESCRIPTION
When writing a custom syntax for, say, a common way that bugs are written, like "bug#123", I wanted to write a custom parser for  auto linking that.

Unfortunately, the first, very hungry syntax eats up 'b', 'u', and 'g', before bailing. Then the custom syntax is left with "#123", and catches nothing.

This makes the inline parser less eager, if custom syntaxes appear to exist. I would make it _always_ less eager, except this less eager parser take **3x** as long in `benchmark.dart` :(

Tests pass.