### PR TITLE
Loosen list separation; no need for a preceding blank line

### DIFF
--- a/lib/src/block_parser.dart
+++ b/lib/src/block_parser.dart
@@ -409,7 +409,7 @@ class ListItem {
 
 /// Base class for both ordered and unordered lists.
 abstract class ListSyntax extends BlockSyntax {
-  bool get canEndBlock => false;
+  bool get canEndBlock => true;
 
   String get listTag;
 

--- a/test/original/paragraphs.unit
+++ b/test/original/paragraphs.unit
@@ -27,20 +27,18 @@ ___
 <<<
 <p>para</p>
 <hr />
->>> consume an unordered list
+>>> are terminated by an unordered list
 para
 * list
 
 <<<
-<p>para
-* list</p>
->>> consume an ordered list
+<p>para</p><ul><li>list</li></ul>
+>>> are terminated by an ordered list
 para
 1. list
 
 <<<
-<p>para
-1. list</p>
+<p>para</p><ol><li>list</li></ol>
 >>> take account of windows line endings
 line1
 

--- a/test/original/unordered_lists.unit
+++ b/test/original/unordered_lists.unit
@@ -71,16 +71,12 @@
 two</p></li><li>three</li></ul>
 >>> can nest lists
 *   one
-
     * nested one
-
     * nested two
 
 *   two
 
 <<<
 <ul><li>
-<p>one</p><ul><li>
-<p>nested one</p></li><li>
-<p>nested two</p></li></ul></li><li>
+<p>one</p><ul><li>nested one</li><li>nested two</li></ul></li><li>
 <p>two</p></li></ul>


### PR DESCRIPTION
Fixes #14 and #74 

Makes it so that the following produces a paragraph followed by a list:

```markdown
text
* item
```

and the following produces a list with a nested list:

```markdown
* first
    * nested
```

In terms of **nested lists**: this brings us **inline** with [most](http://johnmacfarlane.net/babelmark2/?text=*+++one%0A++++*+++list) Markdown implementations, including Markdown.pl, Commonmark, Pandoc, GitHub-Flavored Markdown, and PHP Markdown Extra.

In terms of **paragraphs followed immediately by a line starting with an asterisk**: this brings us

* **inline** with Commonmark, and GitHub-Flavored Markdown, but
* **out of line** with **[most implementations](http://johnmacfarlane.net/babelmark2/?text=one%0A*+++list)**, including Markdown.pl, PHP Markdown Extra, and Pandoc.

What do you think?

I'm voting for this PR because in my mind, Commonmark is the closest thing to a standard, and GitHub-Flavored Markdown is almost certainly the implementation that has parsed the most Markdown text evar <sup>[citation missing]</sup>. PHP Markdown Extra, Markdown.pl, and all the Ruby parsers are big names, but generally the oldest of the Markdown parsers.

cc @munificent @kevmoo @sethladd @kwalrath @caffinatedmonkey