### PR TITLE
Add support for GitHub-Flavored Markdown tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
   * `dart bin/markdown.dart --version` now shows the package version number.
   * The playground app now shows the version number.
 * Improve autolink parsing.
+* Added new table syntax: `TableSyntax`. This can be used by passing
+  `const TableSyntax()` to `markdownToHtml()`'s `blockSyntaxes:` argument.
 * For development: added tool/travis.sh.
 
 ## 0.11.0+1

--- a/test/extensions/tables.unit
+++ b/test/extensions/tables.unit
@@ -26,12 +26,20 @@ head `code` | _cells_
 *text*      | <span>text</span>
 <<<
 <table><thead><tr><th>head <code>code</code></th><th><em>cells</em></th></tr></thead><tbody><tr><td><em>text</em></td><td><span>text</span></td></tr></tbody></table>
->>> cells with inline syntax with pipes
+>>> cells are parsed before inline syntax
 header | _foo | bar_
 -------|------------
 text   | text
 <<<
-<table><thead><tr><th>header</th><th><em>foo | bar</em></th></tr></thead><tbody><tr><td>text</td><td>text</td></tr></tbody></table>
+<table><thead><tr><th>header</th><th>_foo</th><th>bar_</th></tr></thead><tbody><tr><td>text</td><td>text</td></tr></tbody></table>
+>>> cells contain reference links
+header | header
+-------|--------
+text   | [link][here]
+
+[here]: http://url
+<<<
+<table><thead><tr><th>header</th><th>header</th></tr></thead><tbody><tr><td>text</td><td><a href="http://url">link</a></td></tr></tbody></table>
 >>> one column tables
 head
 -----|-----

--- a/test/extensions/tables.unit
+++ b/test/extensions/tables.unit
@@ -1,0 +1,47 @@
+>>> basic table
+head | cells
+-----|------
+body | cells
+
+<<<
+<table><thead><tr><th>head</th><th>cells</th></tr></thead><tbody><tr><td>body</td><td>cells</td></tr></tbody></table>
+>>> multiple rows
+head | cells
+-----|------
+body | cells
+more | cells
+
+<<<
+<table><thead><tr><th>head</th><th>cells</th></tr></thead><tbody><tr><td>body</td><td>cells</td></tr><tr><td>more</td><td>cells</td></tr></tbody></table>
+>>> rows wrapped in pipes
+| head | cells |
+|------|-------|
+| body | cells |
+
+<<<
+<table><thead><tr><th>head</th><th>cells</th></tr></thead><tbody><tr><td>body</td><td>cells</td></tr></tbody></table>
+>>> cells with inline syntax
+head `code` | _cells_
+------------|--------
+*text*      | <span>text</span>
+<<<
+<table><thead><tr><th>head <code>code</code></th><th><em>cells</em></th></tr></thead><tbody><tr><td><em>text</em></td><td><span>text</span></td></tr></tbody></table>
+>>> cells with inline syntax with pipes
+header | _foo | bar_
+-------|------------
+text   | text
+<<<
+<table><thead><tr><th>header</th><th><em>foo | bar</em></th></tr></thead><tbody><tr><td>text</td><td>text</td></tr></tbody></table>
+>>> one column tables
+head
+-----|-----
+body
+<<<
+<table><thead><tr><th>head</th></tr></thead><tbody><tr><td>body</td></tr></tbody></table>
+>>> varying cells per row
+head | foo | bar
+-----|-----
+body
+row with | two cells
+<<<
+<table><thead><tr><th>head</th><th>foo</th><th>bar</th></tr></thead><tbody><tr><td>body</td></tr><tr><td>row with</td><td>two cells</td></tr></tbody></table>

--- a/test/extensions/tables.unit
+++ b/test/extensions/tables.unit
@@ -45,3 +45,11 @@ body
 row with | two cells
 <<<
 <table><thead><tr><th>head</th><th>foo</th><th>bar</th></tr></thead><tbody><tr><td>body</td></tr><tr><td>row with</td><td>two cells</td></tr></tbody></table>
+>>> left, center, and right alignment
+head | cells | here
+:----|:-----:|----:
+body | cells | here
+too | many | cells | here
+
+<<<
+<table><thead><tr><th style="text-align: left;">head</th><th style="text-align: center;">cells</th><th style="text-align: right;">here</th></tr></thead><tbody><tr><td style="text-align: left;">body</td><td style="text-align: center;">cells</td><td style="text-align: right;">here</td></tr><tr><td style="text-align: left;">too</td><td style="text-align: center;">many</td><td style="text-align: right;">cells</td><td>here</td></tr></tbody></table>

--- a/test/markdown_test.dart
+++ b/test/markdown_test.dart
@@ -148,4 +148,6 @@ nyan''',
 
   testFile('extensions/setext_headers_with_ids.unit',
       blockSyntaxes: [const SetextHeaderWithIdSyntax()]);
+
+  testFile('extensions/tables.unit', blockSyntaxes: [const TableSyntax()]);
 }


### PR DESCRIPTION
This fixes #38 

I took [GitHub-Flavored Markdown](https://help.github.com/articles/github-flavored-markdown/#tables) as a best shot at a table spec. Then I wrote a [real spec](https://gist.github.com/srawlins/ad5ef4d153bc0fc223e1) in the spirit of CommonMark.

See the tests for how this feature renders Markdown text to HTML tables.