### PR TITLE
Follow CommonMark convention for language in fenced code blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.10.0
+
+* BREAKING: Now following the CommonMark spec for fenced code blocks.
+  If a language (info string) is provided, it is added as a class to the `code`
+  element with a `language-` prefix.
+
 ## 0.9.0
 
 * BREAKING: The text `[foo] (bar)` no longer renders as an inline link (#53).

--- a/lib/src/block_parser.dart
+++ b/lib/src/block_parser.dart
@@ -341,7 +341,7 @@ class FencedCodeBlockSyntax extends BlockSyntax {
     // Get the syntax identifier, if there is one.
     var match = pattern.firstMatch(parser.current);
     var endBlock = match.group(1);
-    var syntax = match.group(2);
+    var infoString = match.group(2);
 
     var childLines = parseChildLines(parser, endBlock);
 
@@ -351,8 +351,19 @@ class FencedCodeBlockSyntax extends BlockSyntax {
     // Escape the code.
     var escaped = escapeHtml(childLines.join('\n'));
 
-    var element = new Element('pre', [new Element.text('code', escaped)]);
-    if (syntax != '') element.attributes['class'] = syntax;
+    var code = new Element.text('code', escaped);
+
+    // the info-string should be trimmed
+    // http://spec.commonmark.org/0.22/#example-100
+    infoString = infoString.trim();
+    if (infoString.isNotEmpty) {
+      // only use the first word in the syntax
+      // http://spec.commonmark.org/0.22/#example-100
+      infoString = infoString.split(' ').first;
+      code.attributes['class'] = "language-$infoString";
+    }
+
+    var element = new Element('pre', [code]);
 
     return element;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: markdown
-version: 0.9.1-dev
+version: 0.10.0-dev
 author: Dart Team <misc@dartlang.org>
 description: A library for converting markdown to HTML.
 homepage: https://github.com/dart-lang/markdown

--- a/test/extensions/fenced_code_blocks.unit
+++ b/test/extensions/fenced_code_blocks.unit
@@ -12,7 +12,7 @@ code
 ```
 
 <<<
-<pre class="dart"><code>code
+<pre><code class="language-dart">code
 </code></pre>
 >>> escape HTML characters
 ```
@@ -36,7 +36,7 @@ code
 ~~~~~
 
 <<<
-<pre class="dart"><code>code
+<pre><code class="language-dart">code
 </code></pre>
 >>> Pandoc style with inner tildes row
 ~~~~~


### PR DESCRIPTION
Improves CommonMark fenced code test results from 13/27 to 16/27