### PR TITLE
Fixes dart-lang/markdown#83.

### DIFF
--- a/test/original/inline_images.unit
+++ b/test/original/inline_images.unit
@@ -2,19 +2,19 @@
 ![](http://foo.com/foo.png)
 
 <<<
-<p><a href="http://foo.com/foo.png"><img src="http://foo.com/foo.png"></img></a></p>
+<p><img src="http://foo.com/foo.png" /></p>
 >>> alternate text
 ![alternate text](http://foo.com/foo.png)
 
 <<<
-<p><a href="http://foo.com/foo.png"><img alt="alternate text" src="http://foo.com/foo.png"></img></a></p>
+<p><img alt="alternate text" src="http://foo.com/foo.png" /></p>
 >>> title
 ![](http://foo.com/foo.png "optional title")
 
 <<<
-<p><a href="http://foo.com/foo.png" title="optional title"><img src="http://foo.com/foo.png" title="optional title"></img></a></p>
+<p><img src="http://foo.com/foo.png" title="optional title" /></p>
 >>> invalid alt text
 ![`alt`](http://foo.com/foo.png)
 
 <<<
-<p><a href="http://foo.com/foo.png"><img src="http://foo.com/foo.png"></img></a></p>
+<p><img src="http://foo.com/foo.png" /></p>

--- a/test/original/inline_links.unit
+++ b/test/original/inline_links.unit
@@ -13,6 +13,21 @@ links [*are*](http://foo.com) awesome
 
 <<<
 <p>links <a href="http://foo.com"><em>are</em></a> awesome</p>
+>>> image inside link
+links [![](/are.png)](http://foo.com) awesome
+
+<<<
+<p>links <a href="http://foo.com"><img src="/are.png" /></a> awesome</p>
+>>> image with alt inside link
+links [![my alt](/are.png)](http://foo.com) awesome
+
+<<<
+<p>links <a href="http://foo.com"><img alt="my alt" src="/are.png" /></a> awesome</p>
+>>> image with title inside link
+links [![](/are.png "my title")](http://foo.com) awesome
+
+<<<
+<p>links <a href="http://foo.com"><img src="/are.png" title="my title" /></a> awesome</p>
 >>> no URL
 links [are]() awesome
 

--- a/test/original/reference_images.unit
+++ b/test/original/reference_images.unit
@@ -3,22 +3,22 @@
 [foo]: http://foo.com/foo.png
 
 <<<
-<p><a href="http://foo.com/foo.png"><img src="http://foo.com/foo.png"></img></a></p>
+<p><img src="http://foo.com/foo.png" /></p>
 >>> alternate text
 ![alternate text][foo]
 [foo]: http://foo.com/foo.png
 
 <<<
-<p><a href="http://foo.com/foo.png"><img alt="alternate text" src="http://foo.com/foo.png"></img></a></p>
+<p><img alt="alternate text" src="http://foo.com/foo.png" /></p>
 >>> title
 ![][foo]
 [foo]: http://foo.com/foo.png "optional title"
 
 <<<
-<p><a href="http://foo.com/foo.png" title="optional title"><img src="http://foo.com/foo.png" title="optional title"></img></a></p>
+<p><img src="http://foo.com/foo.png" title="optional title" /></p>
 >>> invalid alt text
 ![`alt`][foo]
 [foo]: http://foo.com/foo.png "optional title"
 
 <<<
-<p><a href="http://foo.com/foo.png" title="optional title"><img src="http://foo.com/foo.png" title="optional title"></img></a></p>
+<p><img src="http://foo.com/foo.png" title="optional title" /></p>


### PR DESCRIPTION
Fixes dart-lang/markdown#83.

An inline image is now rendered correctly, sans anchor element,
and not emitting a close tag for the image element. Unit tests
have been updated to match correct rendering.

An inline image may also be placed inside the content of a link,
and this case is also rendered correctly. I added three new unit
tests for this.

This *would* boost the CommonMark test for images from 1/22 to
9/22 and the test for links from 33/79 to 53/79, except the
CommonMark tests are sensitive to attribute order. (See separate
pull request on dart-lang/markdown#51.)