### PR TITLE
Support shortuct reference links and images

### DIFF
--- a/test/original/reference_images.unit
+++ b/test/original/reference_images.unit
@@ -22,3 +22,9 @@
 
 <<<
 <p><img src="http://foo.com/foo.png" title="optional title" /></p>
+>>> shortcut reference image
+![foo]
+
+[foo]: http://foo.com/foo.png
+<<<
+<p><img alt="foo" src="http://foo.com/foo.png" /></p>

--- a/test/original/reference_links.unit
+++ b/test/original/reference_links.unit
@@ -57,3 +57,9 @@ links [ARE][] awesome
 
 <<<
 <p>links <a href="http://foo.com">ARE</a> awesome</p>
+>>> shortcut reference links
+links [are] awesome
+
+[are]: http://foo.com
+<<<
+<p>links <a href="http://foo.com">are</a> awesome</p>


### PR DESCRIPTION
This adds support for:

```markdown
[foo] and ![bar].

[foo]: http://example.com
[bar]: http://example.com/bar.png
```

CommonMark: http://spec.commonmark.org/0.25/#shortcut-reference-link

This bumps our CommonMark compliance from 401 to 428. Woohoo!