### PR TITLE
A code blocks cannot interrupt a paragraph

### DIFF
--- a/lib/src/block_parser.dart
+++ b/lib/src/block_parser.dart
@@ -268,6 +268,8 @@ class BlockquoteSyntax extends BlockSyntax {
 class CodeBlockSyntax extends BlockSyntax {
   RegExp get pattern => _indentPattern;
 
+  bool get canEndBlock => false;
+
   const CodeBlockSyntax();
 
   List<String> parseChildLines(BlockParser parser) {

--- a/test/original/paragraphs.unit
+++ b/test/original/paragraphs.unit
@@ -48,3 +48,10 @@ line2
 <<<
 <p>line1</p>
 <p>line2</p>
+>>> cannot be terminated by indented code blocks
+para
+    not code
+
+<<<
+<p>para
+    not code</p>


### PR DESCRIPTION
From CommonMark: http://spec.commonmark.org/0.25/#indented-code-blocks

> An indented code block cannot interrupt a paragraph.
> (This allows hanging indents and the like.)

This bumps our CommonMark compliance from 401 to 407.