### PR TITLE
Using CommonMark's 'tight' and 'loose' lists

### DIFF
--- a/lib/src/document.dart
+++ b/lib/src/document.dart
@@ -73,22 +73,8 @@ class Document {
   }
 
   /// Parses the given [lines] of Markdown to a series of AST nodes.
-  List<Node> parseLines(List<String> lines) {
-    var parser = new BlockParser(lines, this);
-
-    var blocks = <Node>[];
-    while (!parser.isDone) {
-      for (var syntax in parser.blockSyntaxes) {
-        if (syntax.canParse(parser)) {
-          var block = syntax.parse(parser);
-          if (block != null) blocks.add(block);
-          break;
-        }
-      }
-    }
-
-    return blocks;
-  }
+  List<Node> parseLines(List<String> lines) =>
+      new BlockParser(lines, this).parseLines();
 
   /// Parses the given inline Markdown [text] to a series of AST nodes.
   List<Node> parseInline(String text) => new InlineParser(text, this).parse();

--- a/test/original/unordered_lists.unit
+++ b/test/original/unordered_lists.unit
@@ -35,7 +35,8 @@
 *   three
 
 <<<
-<ul><li>one</li><li>
+<ul><li>
+<p>one</p></li><li>
 <p>two</p></li><li>
 <p>three</p></li></ul>
 >>> do not force paragraph if item is already block
@@ -66,9 +67,8 @@
 *   three
 
 <<<
-<ul><li>
-<p>one
-two</p></li><li>three</li></ul>
+<ul><li>one
+two</li><li>three</li></ul>
 >>> can nest lists
 *   one
     * nested one


### PR DESCRIPTION
This switches our definition of "block-level" list items and "inline" list items to CommonMark's [loose and tight lists](http://spec.commonmark.org/0.25/#lists).

It improves our CommonMark score from 465 to 468, but I think that this improves the score found in #102.