### PR TITLE
Fixes for blockquotes, list items, hr's, setext headers

### DIFF
--- a/test/original/block_quotes.unit
+++ b/test/original/block_quotes.unit
@@ -25,3 +25,18 @@
 <p>two</p>
 <blockquote>
 <p>three</p></blockquote></blockquote></blockquote>
+>>> quote turns what might be an h1 into nothing
+> quote
+===
+
+<<<
+<blockquote>
+<p>quote===</p></blockquote>
+>>> quote turns what might be an h2 into an hr
+> quote
+---
+
+<<<
+<blockquote>
+<p>quote</p></blockquote>
+<hr />

--- a/test/original/setext_headers.unit
+++ b/test/original/setext_headers.unit
@@ -20,27 +20,3 @@ text
 
 <<<
 <p>-</p>
->>> h1 turns preceding list into text
-- list
-===
-
-<<<
-<h1>- list</h1>
->>> h2 turns preceding list into text
-- list
-===
-
-<<<
-<h1>- list</h1>
->>> h1 turns preceding blockquote into text
-> quote
-===
-
-<<<
-<h1>> quote</h1>
->>> h2 turns preceding blockquote into text
-> quote
-===
-
-<<<
-<h1>> quote</h1>

--- a/test/original/unordered_lists.unit
+++ b/test/original/unordered_lists.unit
@@ -80,3 +80,16 @@ two</p></li><li>three</li></ul>
 <ul><li>
 <p>one</p><ul><li>nested one</li><li>nested two</li></ul></li><li>
 <p>two</p></li></ul>
+>>> list item turns what might be an h1 into nothing
+- list
+===
+
+<<<
+<ul><li>list===</li></ul>
+>>> list item turns what might be an h2 into nothing
+- list
+---
+
+<<<
+<ul><li>list</li></ul>
+<hr />


### PR DESCRIPTION
I intended to fix some blockquote CommonMark compliance, but because of how paragraph continuations work, etc, this includes a few fixes. 477 passing CommonMark specs, up from 465:

```
BEFORE

  18 of   25 –  72.0%  Block quotes
  25 of   47 –  53.2%  List items
  16 of   26 –  61.5%  Setext headings
  16 of   19 –  84.2%  Thematic breaks
...
465 of  616 –  75.5%  TOTAL

AFTER

  22 of   25 –  88.0%  Block quotes
  27 of   47 –  57.4%  List items
  21 of   26 –  80.8%  Setext headings
  17 of   19 –  89.5%  Thematic breaks
...
 477 of  616 –  77.4%  TOTAL
```