### PR TITLE
Ensure that 1.18.1 and 1.17.1 are running

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,12 @@ sudo: false
 dart:
   - stable
   - dev
+  - 1.18.1
+  - 1.17.1
+matrix:
+  allow_failures:
+  # We need Travis to run Trusty for Dart 1.19+
+  # Dart issue here https://github.com/travis-ci/travis-ci/issues/6415
+  # General issue here: https://github.com/travis-ci/travis-ci/issues/5695
+  - dart: dev
+  - dart: stable


### PR DESCRIPTION
But allow stable and dev to fail – since these might be 1.19+
Hoping to get travis fixed soon