### PR TITLE
Re-enable dev and stable SDK failures for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,3 @@ dart:
   - 1.18.1
   - 1.17.1
 script: tool/travis.sh
-matrix:
-  allow_failures:
-  # We need Travis to run Trusty for Dart 1.19+
-  # Dart issue here https://github.com/travis-ci/travis-ci/issues/6415
-  # General issue here: https://github.com/travis-ci/travis-ci/issues/5695
-  - dart: dev
-  - dart: stable


### PR DESCRIPTION
Dev 1.19-dev.5 fixed it's issue with Ubuntu precise