### PR TITLE
Add util.dart to export and bump version for custom inline parsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.11.2
+
+* Add src/util.dart to exports.
+
 ## 0.11.1
 
 * Added version information:

--- a/lib/markdown.dart
+++ b/lib/markdown.dart
@@ -12,3 +12,4 @@ export 'src/extension_set.dart';
 export 'src/html_renderer.dart';
 export 'src/inline_parser.dart';
 export 'src/version.dart';
+export 'src/util.dart';

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 /// The current version of markdown.
-final String version = '0.11.1';
+final String version = '0.11.2';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: markdown
-version: 0.11.1
+version: 0.11.2
 author: Dart Team <misc@dartlang.org>
 description: A library for converting markdown to HTML.
 homepage: https://github.com/dart-lang/markdown


### PR DESCRIPTION
As part of [dartdoc issue 1147](https://github.com/dart-lang/dartdoc/issues/1147), I need to write a custom version of [AutolinkSyntax](https://github.com/dart-lang/markdown/blob/master/lib/src/inline_parser.dart#L248) for dartdoc.  This is easier to make consistent if I have access to [escapeHtml](https://github.com/dart-lang/markdown/blob/master/lib/src/util.dart#L4).

Alternatively, I can implement the fix here in its entirely (impacting all markdown users) or cut-and-paste the relatively small escapeHtml function.