### PR TITLE
#153: support escape pipe in table

### DIFF
--- a/lib/src/block_parser.dart
+++ b/lib/src/block_parser.dart
@@ -815,9 +815,18 @@ class TableSyntax extends BlockSyntax {
         .replaceFirst(_closingPipe, '');
     var cells = line.split(_pipePattern);
     parser.advance();
-    var row = <Element>[];
+    var row = <Element>[], precell;
 
     for (String cell in cells) {
+      if (precell != null) {
+        cell = precell + cell;
+        precell = null;
+      }
+      if (cell.endsWith('\\')) {
+        precell = cell.substring(0, cell.length - 1) + '|';
+        continue;
+      }
+
       var contents = new UnparsedContent(cell);
       row.add(new Element(cellType, [contents]));
     }

--- a/test/extensions/tables.unit
+++ b/test/extensions/tables.unit
@@ -76,3 +76,11 @@ too | many | cells | here
 
 <<<
 <table><thead><tr><th style="text-align: left;">head</th><th style="text-align: center;">cells</th><th style="text-align: right;">here</th></tr></thead><tbody><tr><td style="text-align: left;">body</td><td style="text-align: center;">cells</td><td style="text-align: right;">here</td></tr><tr><td style="text-align: left;">too</td><td style="text-align: center;">many</td><td style="text-align: right;">cells</td><td>here</td></tr></tbody></table>
+>>> escape pipe
+| Name     | Character |
+| ---      | ---       |
+| Backtick | `         |
+| Pipe     | \|        |
+
+<<<
+<table><thead><tr><th>Name</th><th>Character</th></tr></thead><tbody><tr><td>Backtick</td><td>`</td></tr><tr><td>Pipe</td><td>|</td></tr></tbody></table>


### PR DESCRIPTION
A quick fix. It doesn't consider the case: `\\|`, but it shall be good enough. After all, most users will do `\\ |` instead.