### PR TITLE
Fix #156: ListSyntax preserves line breaks

### DIFF
--- a/lib/src/block_parser.dart
+++ b/lib/src/block_parser.dart
@@ -672,7 +672,7 @@ abstract class ListSyntax extends BlockSyntax {
         }
 
         // Anything else is paragraph continuation text.
-        var continuedLine = childLines.last + parser.current;
+        var continuedLine = childLines.last + '\n' + parser.current;
         childLines
           ..removeLast()
           ..add(continuedLine);

--- a/test/original/unordered_lists.unit
+++ b/test/original/unordered_lists.unit
@@ -83,7 +83,8 @@ two</li><li>three</li></ul>
 ===
 
 <<<
-<ul><li>list===</li></ul>
+<ul><li>list
+===</li></ul>
 >>> list item turns what might be an h2 into nothing
 - list
 ---
@@ -91,3 +92,11 @@ two</li><li>three</li></ul>
 <<<
 <ul><li>list</li></ul>
 <hr />
+>>> list
+* line1
+line2
+line3
+<<<
+<ul><li>line1
+line2
+line3</li></ul>


### PR DESCRIPTION
It can be subjective, but I think it is better to preserve the line breaks like Github does.