### PR TITLE
Rename the Link class to LinkReference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
-## 1.1.2-dev
+## 2.0.0-dev
 
+* **Breaking change:** The `Link` class has been renamed `LinkReference`, and
+  the `Document` field, `refLinks`, has been renamed `linkReferences`.
 * Overhaul support for emphasis (`*foo*` and `_foo_`) and strong emphasis
   (`**foo**` and `__foo__`), dramatically improving CommonMark compliance.
 * Improve support for tab characters, and horizontal rules.

--- a/lib/src/block_parser.dart
+++ b/lib/src/block_parser.dart
@@ -1007,8 +1007,8 @@ class ParagraphSyntax extends BlockSyntax {
     // References are case-insensitive.
     label = label.toLowerCase().trim();
 
-    parser.document.refLinks
-        .putIfAbsent(label, () => new Link(label, destination, title));
+    parser.document.linkReferences
+        .putIfAbsent(label, () => new LinkReference(label, destination, title));
     return true;
   }
 }

--- a/lib/src/document.dart
+++ b/lib/src/document.dart
@@ -9,7 +9,7 @@ import 'inline_parser.dart';
 
 /// Maintains the context needed to parse a Markdown document.
 class Document {
-  final Map<String, Link> refLinks = {};
+  final Map<String, LinkReference> linkReferences = {};
   Iterable<BlockSyntax> blockSyntaxes;
   Iterable<InlineSyntax> inlineSyntaxes;
   ExtensionSet extensionSet;
@@ -56,9 +56,25 @@ class Document {
   }
 }
 
-class Link {
-  final String id;
-  final String url;
+/// A [link reference
+/// definition](http://spec.commonmark.org/0.28/#link-reference-definitions).
+class LinkReference {
+  /// The [link label](http://spec.commonmark.org/0.28/#link-label).
+  ///
+  /// Temporarily, this class is also being used to represent the link data for
+  /// an inline link (the destination and title), but this should change before
+  /// the package is released.
+  final String label;
+
+  /// The [link destination](http://spec.commonmark.org/0.28/#link-destination).
+  final String destination;
+
+  /// The [link title](http://spec.commonmark.org/0.28/#link-title).
   final String title;
-  Link(this.id, this.url, this.title);
+
+  /// Construct a new [LinkReference], with all necessary fields.
+  ///
+  /// If the parsed link reference definition does not include a title, use
+  /// `null` for the [title] parameter.
+  LinkReference(this.label, this.destination, this.title);
 }

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 /// The current version of markdown.
-final String version = '1.1.2-dev';
+final String version = '2.0.0-dev';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: markdown
-version: 1.1.2-dev
+version: 2.0.0-dev
 author: Dart Team <misc@dartlang.org>
 description: A library for converting markdown to HTML.
 homepage: https://github.com/dart-lang/markdown


### PR DESCRIPTION
After receiving a fair amount of feedback on #202, I think it would be good to do my best to open some preliminary PRs to overhaul links. This is the first, renaming `Link` to `LinkReference`, so that I can create a new class, `Link`, that will represent something like a link, or a possible link. The `LinkReference` is a different concept. Other changes (mostly just moving to CommonMark terms):

* `Link.id` is now `LinkReference.label`
* `Link.url` is now `LinkReference.destination`
* `Document.refLinks` is now `Document.linkReferences`