### PR TITLE
Remove the deprecated `ExtensionSet.gitHub` field.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * **Breaking change:** The `Link` class has been renamed `LinkReference`, and
   the `Document` field, `refLinks`, has been renamed `linkReferences`.
+* **Breaking change:** Remove the deprecated `ExtensionSet.gitHub` field.
+  Use `ExtensionSet.gitHubFlavored` instead.
 * Overhaul support for emphasis (`*foo*` and `_foo_`) and strong emphasis
   (`**foo**` and `__foo__`), dramatically improving CommonMark compliance.
 * Improve support for tab characters, and horizontal rules.

--- a/lib/src/extension_set.dart
+++ b/lib/src/extension_set.dart
@@ -57,10 +57,6 @@ class ExtensionSet {
     new AutolinkExtensionSyntax(),
   ]);
 
-  /// The deprecated name for the [gitHubFlavored] extension set.
-  @deprecated
-  static final ExtensionSet gitHub = gitHubFlavored;
-
   final List<BlockSyntax> blockSyntaxes;
   final List<InlineSyntax> inlineSyntaxes;
 


### PR DESCRIPTION
Use `ExtensionSet.gitHubFlavored` instead.