### PR TITLE
Add Document option to prevent HTML escaping.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,3 +8,4 @@ Google Inc.
 David Peek <ninjascript@gmail.com>
 Daniel Schubert <daniel.schubert+github.com@gmail.com>
 Jirka Daněk <dnk@mail.muni.cz>
+Seth Westphal <westy92@gmail.com>

--- a/lib/src/document.dart
+++ b/lib/src/document.dart
@@ -13,7 +13,7 @@ class Document {
   final ExtensionSet extensionSet;
   final Resolver linkResolver;
   final Resolver imageLinkResolver;
-  final bool guardHtml;
+  final bool encodeHtml;
   final _blockSyntaxes = new Set<BlockSyntax>();
   final _inlineSyntaxes = new Set<InlineSyntax>();
 
@@ -26,7 +26,7 @@ class Document {
       ExtensionSet extensionSet,
       this.linkResolver,
       this.imageLinkResolver,
-      this.guardHtml = false})
+      this.encodeHtml = true})
       : this.extensionSet = extensionSet ?? ExtensionSet.commonMark {
     this._blockSyntaxes
       ..addAll(blockSyntaxes ?? [])

--- a/lib/src/document.dart
+++ b/lib/src/document.dart
@@ -13,6 +13,7 @@ class Document {
   final ExtensionSet extensionSet;
   final Resolver linkResolver;
   final Resolver imageLinkResolver;
+  final bool guardHtml;
   final _blockSyntaxes = new Set<BlockSyntax>();
   final _inlineSyntaxes = new Set<InlineSyntax>();
 
@@ -24,7 +25,8 @@ class Document {
       Iterable<InlineSyntax> inlineSyntaxes,
       ExtensionSet extensionSet,
       this.linkResolver,
-      this.imageLinkResolver})
+      this.imageLinkResolver,
+      this.guardHtml = false})
       : this.extensionSet = extensionSet ?? ExtensionSet.commonMark {
     this._blockSyntaxes
       ..addAll(blockSyntaxes ?? [])

--- a/lib/src/inline_parser.dart
+++ b/lib/src/inline_parser.dart
@@ -82,7 +82,7 @@ class InlineParser {
 
     syntaxes.addAll(_defaultSyntaxes);
 
-    if (!this.document.guardHtml) {
+    if (this.document.encodeHtml) {
       syntaxes.addAll(_htmlSyntaxes);
     }
 

--- a/lib/src/inline_parser.dart
+++ b/lib/src/inline_parser.dart
@@ -25,6 +25,16 @@ class InlineParser {
     new TextSyntax(r' \* '),
     // "_" surrounded by spaces is left alone.
     new TextSyntax(r' _ '),
+    // Parse "**strong**" and "*emphasis*" tags.
+    new TagSyntax(r'\*+', requiresDelimiterRun: true),
+    // Parse "__strong__" and "_emphasis_" tags.
+    new TagSyntax(r'_+', requiresDelimiterRun: true),
+    new CodeSyntax(),
+    // We will add the LinkSyntax once we know about the specific link resolver.
+  ]);
+
+  static final List<InlineSyntax> _htmlSyntaxes =
+      new List<InlineSyntax>.unmodifiable(<InlineSyntax>[
     // Leave already-encoded HTML entities alone. Ensures we don't turn
     // "&amp;" into "&amp;amp;"
     new TextSyntax(r'&[#a-zA-Z0-9]*;'),
@@ -32,11 +42,6 @@ class InlineParser {
     new TextSyntax(r'&', sub: '&amp;'),
     // Encode "<". (Why not encode ">" too? Gruber is toying with us.)
     new TextSyntax(r'<', sub: '&lt;'),
-    // Parse "**strong**" and "*emphasis*" tags.
-    new TagSyntax(r'\*+', requiresDelimiterRun: true),
-    // Parse "__strong__" and "_emphasis_" tags.
-    new TagSyntax(r'_+', requiresDelimiterRun: true),
-    new CodeSyntax(),
     // We will add the LinkSyntax once we know about the specific link resolver.
   ]);
 
@@ -76,6 +81,10 @@ class InlineParser {
     }
 
     syntaxes.addAll(_defaultSyntaxes);
+
+    if (!this.document.guardHtml) {
+      syntaxes.addAll(_htmlSyntaxes);
+    }
 
     // Custom link resolvers go after the generic text syntax.
     syntaxes.insertAll(1, [

--- a/test/document_test.dart
+++ b/test/document_test.dart
@@ -7,8 +7,8 @@ import 'package:test/test.dart';
 
 void main() {
   group('Document', () {
-    test('guardHtml prevents less than and ampersand escaping', () {
-      var document = new Document(guardHtml: true);
+    test('encodeHtml prevents less than and ampersand escaping', () {
+      var document = new Document(encodeHtml: false);
       var result = document.parseInline('< &');
       expect(result, hasLength(1));
       expect(result[0], new isInstanceOf<Text>());

--- a/test/document_test.dart
+++ b/test/document_test.dart
@@ -1,0 +1,18 @@
+// Copyright (c) 2011, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:markdown/markdown.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Document', () {
+    test('guardHtml prevents less than and ampersand escaping', () {
+      var document = new Document(guardHtml: true);
+      var result = document.parseInline('< &');
+      expect(result, hasLength(1));
+      expect(result[0], new isInstanceOf<Text>());
+      expect((result[0] as Text).text, equals('< &'));
+    });
+  });
+}


### PR DESCRIPTION
Fixes #211.

I wasn't sure how to structure the added test since I didn't see any other `Document`-specific tests.