### PR TITLE
Remove initial number stripping from header IDs; GitHub doesn't do it

### DIFF
--- a/lib/src/block_parser.dart
+++ b/lib/src/block_parser.dart
@@ -199,7 +199,6 @@ abstract class BlockSyntax {
       element.children.first.textContent
           .toLowerCase()
           .trim()
-          .replaceFirst(new RegExp(r'^[^a-z]+'), '')
           .replaceAll(new RegExp(r'[^a-z0-9 _-]'), '')
           .replaceAll(new RegExp(r'\s'), '-');
 }

--- a/test/extensions/headers_with_ids.unit
+++ b/test/extensions/headers_with_ids.unit
@@ -7,7 +7,7 @@
 ## 2. header again
 
 <<<
-<h2 id="header-again">2. header again</h2>
+<h2 id="2-header-again">2. header again</h2>
 >>> header with inline syntaxes
 ### headers **rock** `etc.`
 
@@ -25,3 +25,13 @@
 # *headers* etc.
 <<<
 <h1 id="headers-etc"><em>headers</em> etc.</h1>
+>>> numbers-only headers (like a changelog)
+# 1.2.34
+
+## 1.23.4
+
+## 1.2.3+4
+<<<
+<h1 id="1234">1.2.34</h1>
+<h2 id="1234-2">1.23.4</h2>
+<h2 id="1234-3">1.2.3+4</h2>


### PR DESCRIPTION
Fixes #226 