### PR TITLE
Prepare for upcoming change to HttpRequest and HttpClientResponse

### DIFF
--- a/tool/update_blns.dart
+++ b/tool/update_blns.dart
@@ -12,7 +12,10 @@ Future<Null> main() async {
   try {
     var request = await client.getUrl(Uri.parse(_blnsJsonRawUrl));
     var response = await request.close();
-    json = (jsonDecode(await response.transform(utf8.decoder).join('')) as List)
+    json = (jsonDecode(await response
+            .cast<List<int>>()
+            .transform(utf8.decoder)
+            .join('')) as List)
         .cast<String>();
   } finally {
     client.close();

--- a/tool/update_emojis.dart
+++ b/tool/update_emojis.dart
@@ -10,7 +10,8 @@ Future<Null> main() async {
   var client = HttpClient();
   var request = await client.getUrl(Uri.parse(_emojisJsonRawUrl));
   var response = await request.close();
-  var json = jsonDecode(await response.transform(utf8.decoder).join(''))
+  var json = jsonDecode(
+          await response.cast<List<int>>().transform(utf8.decoder).join(''))
       .map((alias, info) => MapEntry(alias, info.cast<String, dynamic>()))
       .cast<String, Map<String, dynamic>>();
   var emojisContent = StringBuffer('''


### PR DESCRIPTION
An upcoming change to the Dart SDK will change `HttpRequest` and
`HttpClientResponse` from implementing `Stream<List<int>>` to
implementing `Stream<Uint8List>`.

This forwards-compatible change prepares for that SDK breaking
change by casting the Stream to `List<int>` before transforming
it.

https://github.com/dart-lang/sdk/issues/36900