### PR TITLE
Fix errant return

### DIFF
--- a/tool/stats.dart
+++ b/tool/stats.dart
@@ -105,7 +105,7 @@ Future<void> _processConfig(
 
   for (var entry in sections.entries) {
     if (specifiedSection != null && entry.key != specifiedSection) {
-      return;
+      continue;
     }
 
     final units = <DataCase>[];


### PR DESCRIPTION
This `return` should have been converted to a `continue` in https://github.com/dart-lang/markdown/commit/239ca0bd8b096206cb5ecd3bf8db70816d57a085#diff-f19fcc539c0ac93fbc53aa06c91aa4cf, so that verbose errors are printed to stdout.