### PR TITLE
Reduce time to parse a large Markdown document by about half

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 * Drop support for Dart 2.0.0 through 2.1.0.
 * Recognize Unicode ellipsis (…) and other Unicode punctuation as punctuation
   when parsing potential emphasis.
+* Reduce time to parse a large HTML-block-free Markdown document (such as that
+  in #271) by about half.
 
 ## 2.1.1
 


### PR DESCRIPTION
Largely addresses #271 but I might squeeze some more performance, so not closing yet.