### PR TITLE
Lint: bump pedantic and handle consequences

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:pedantic/analysis_options.yaml
+include: package:pedantic/analysis_options.1.9.0.yaml
 analyzer:
   language:
     strict-inference: true
@@ -7,7 +7,6 @@ analyzer:
     implicit-casts: false
   errors:
     dead_code: error
-    override_on_non_overriding_method: error
     unused_element: error
     unused_import: error
     unused_local_variable: error
@@ -15,8 +14,6 @@ analyzer:
     inference_failure_on_untyped_parameter: ignore
 linter:
   rules:
-    #- annotate_overrides
-    - avoid_null_checks_in_equality_operators
     - await_only_futures
     - camel_case_types
     # https://github.com/dart-lang/linter/issues/574
@@ -29,13 +26,9 @@ linter:
     - iterable_contains_unrelated_type
     - list_remove_unrelated_type
     - non_constant_identifier_names
-    - omit_local_variable_types
     - only_throw_errors
     - overridden_fields
     - package_api_docs
-    - prefer_final_fields
-    - prefer_generic_function_type_aliases
-    #- prefer_single_quotes
     - test_types_in_equals
     - throw_in_finally
     - unnecessary_brace_in_string_interps

--- a/benchmark/benchmark.dart
+++ b/benchmark/benchmark.dart
@@ -4,17 +4,16 @@
 
 import 'dart:io';
 
-import 'package:path/path.dart' as p;
-
 import 'package:markdown/markdown.dart';
+import 'package:path/path.dart' as p;
 
 const numTrials = 100;
 const runsPerTrial = 50;
 
-final source = loadFile('input.md');
-final expected = loadFile('output.html');
+final source = _loadFile('input.md');
+final expected = _loadFile('output.html');
 
-void main(List<String> args) {
+void main() {
   var best = double.infinity;
 
   // Run the benchmark several times. This ensures the VM is warmed up and lets
@@ -45,23 +44,23 @@ void main(List<String> args) {
     // Don't print the first run. It's always terrible since the VM hasn't
     // warmed up yet.
     if (i == 0) continue;
-    printResult("Run ${padLeft('#$i', 3)}", elapsed);
+    _printResult("Run ${_padLeft('#$i', 3)}", elapsed);
   }
 
-  printResult('Best   ', best);
+  _printResult('Best   ', best);
 }
 
-String loadFile(String name) {
+String _loadFile(String name) {
   var path = p.join(p.dirname(p.fromUri(Platform.script)), name);
   return File(path).readAsStringSync();
 }
 
-void printResult(String label, double time) {
-  print('$label: ${padLeft(time.toStringAsFixed(2), 4)}ms '
+void _printResult(String label, double time) {
+  print('$label: ${_padLeft(time.toStringAsFixed(2), 4)}ms '
       "${'=' * ((time * 20).toInt())}");
 }
 
-String padLeft(input, int length) {
+String _padLeft(String input, int length) {
   var result = input.toString();
   if (result.length < length) {
     result = ' ' * (length - result.length) + result;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,6 @@ dev_dependencies:
   io: ^0.3.2+1
   js: ^0.6.1
   path: ^1.3.1
-  pedantic: ^1.8.0
+  pedantic: ^1.9.0
   test: ^1.2.0
   yaml: ^2.1.8


### PR DESCRIPTION
* bump pedantic to 1.9.0
* pin analysis options to 1.9.0
* remove options now-included-from-pedantic
* handle a few types in benchmark
* make helpers in benchmark private