### PR TITLE
Add remaining html5 'block level' tags

### DIFF
--- a/lib/src/html_renderer.dart
+++ b/lib/src/html_renderer.dart
@@ -53,6 +53,23 @@ const _blockTags = [
   'p',
   'pre',
   'ul',
+  'address',
+  'article',
+  'aside',
+  'details',
+  'dd',
+  'div',
+  'dl',
+  'dt',
+  'figcaption',
+  'figure',
+  'footer',
+  'header',
+  'hgroup',
+  'main',
+  'nav',
+  'section',
+  'table'
 ];
 
 /// Translates a parsed AST to HTML.


### PR DESCRIPTION
I couldn't find a unit test for this. I did run the comparison tool against angular dart's docs and, as expected, there was no diff.

This change is meant to help with extensions that may render elements of these other tags (I wrote some for my blog). That is, it makes the `HtmlRenderer` a little more extension-agnostic.