### PR TITLE
Remove redundant LinkSyntax; remove erroneous comment

### DIFF
--- a/lib/src/inline_parser.dart
+++ b/lib/src/inline_parser.dart
@@ -17,7 +17,6 @@ class InlineParser {
     EmailAutolinkSyntax(),
     AutolinkSyntax(),
     LineBreakSyntax(),
-    LinkSyntax(),
     ImageSyntax(),
     // Allow any punctuation to be escaped.
     EscapeSyntax(),
@@ -44,7 +43,6 @@ class InlineParser {
     TextSyntax(r'<', sub: '&lt;', startCharacter: $lt),
     // Encode ">".
     TextSyntax(r'>', sub: '&gt;', startCharacter: $gt),
-    // We will add the LinkSyntax once we know about the specific link resolver.
   ]);
 
   /// The string of Markdown being parsed.


### PR DESCRIPTION
The LinkSyntax is added, per the comment within _defaultSyntaxes, in the
constructor, so I believe it was not intended to be in the default
syntaxes list without the right resolver set.

The comment within _htmlSyntaxes didn't make sense to me, so I believe
it to be an error (copy and paste?).

Both changes are no-ops, just clean ups I noticed while looking through
the code. Hopefully I have not misunderstood.

Thanks!