### PR TITLE
Make pre-define extension sets immutable

### DIFF
--- a/lib/src/extension_set.dart
+++ b/lib/src/extension_set.dart
@@ -15,14 +15,21 @@ class ExtensionSet {
   /// fenced code blocks, or inline HTML.
   ///
   /// [Markdown.pl]: http://daringfireball.net/projects/markdown/syntax
-  static final ExtensionSet none = ExtensionSet([], []);
+  static final ExtensionSet none = ExtensionSet(
+    List<BlockSyntax>.unmodifiable(<BlockSyntax>[]),
+    List<InlineSyntax>.unmodifiable(<InlineSyntax>[]),
+  );
 
   /// The [commonMark] extension set is close to compliance with [CommonMark].
   ///
   /// [CommonMark]: http://commonmark.org/
   static final ExtensionSet commonMark = ExtensionSet(
-    [const FencedCodeBlockSyntax()],
-    [InlineHtmlSyntax()],
+    List<BlockSyntax>.unmodifiable(
+      <BlockSyntax>[const FencedCodeBlockSyntax()],
+    ),
+    List<InlineSyntax>.unmodifiable(
+      <InlineSyntax>[InlineHtmlSyntax()],
+    ),
   );
 
   /// The [gitHubWeb] extension set renders Markdown similarly to GitHub.
@@ -34,30 +41,44 @@ class ExtensionSet {
   /// linkable IDs.)
   ///
   /// [GitHub flavored Markdown]: https://github.github.com/gfm/
-  static final ExtensionSet gitHubWeb = ExtensionSet([
-    const FencedCodeBlockSyntax(),
-    const HeaderWithIdSyntax(),
-    const SetextHeaderWithIdSyntax(),
-    const TableSyntax()
-  ], [
-    InlineHtmlSyntax(),
-    StrikethroughSyntax(),
-    EmojiSyntax(),
-    AutolinkExtensionSyntax(),
-  ]);
+  static final ExtensionSet gitHubWeb = ExtensionSet(
+    List<BlockSyntax>.unmodifiable(
+      <BlockSyntax>[
+        const FencedCodeBlockSyntax(),
+        const HeaderWithIdSyntax(),
+        const SetextHeaderWithIdSyntax(),
+        const TableSyntax(),
+      ],
+    ),
+    List<InlineSyntax>.unmodifiable(
+      <InlineSyntax>[
+        InlineHtmlSyntax(),
+        StrikethroughSyntax(),
+        EmojiSyntax(),
+        AutolinkExtensionSyntax()
+      ],
+    ),
+  );
 
   /// The [gitHubFlavored] extension set is close to compliance with the [GitHub
   /// flavored Markdown spec].
   ///
   /// [GitHub flavored Markdown]: https://github.github.com/gfm/
-  static final ExtensionSet gitHubFlavored = ExtensionSet([
-    const FencedCodeBlockSyntax(),
-    const TableSyntax()
-  ], [
-    InlineHtmlSyntax(),
-    StrikethroughSyntax(),
-    AutolinkExtensionSyntax(),
-  ]);
+  static final ExtensionSet gitHubFlavored = ExtensionSet(
+    List<BlockSyntax>.unmodifiable(
+      <BlockSyntax>[
+        const FencedCodeBlockSyntax(),
+        const TableSyntax(),
+      ],
+    ),
+    List<InlineSyntax>.unmodifiable(
+      <InlineSyntax>[
+        InlineHtmlSyntax(),
+        StrikethroughSyntax(),
+        AutolinkExtensionSyntax()
+      ],
+    ),
+  );
 
   final List<BlockSyntax> blockSyntaxes;
   final List<InlineSyntax> inlineSyntaxes;


### PR DESCRIPTION
This change makes the pre-defined extension sets, none, commonMark, gitHubFlavored, and gitHubWeb, immutable. This is a breaking change only if consumers of the markdown package are modifying the blockSyntaxes or inlineSyntaxes lists of a pre-defined extension set. Causing this type of use of the pre-defined extension sets to break is probably a good thing since modified pre-defined extension sets could have unexpected or unintended side-effects.

I tested this change against the blns_test, document_test, markdown_test, and version_test. All tests passed without errors.