### PR TITLE
README Documentation on Extension sets is out-of-date

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,29 +57,55 @@ void main() {
 ### Extension sets
 
 To make extension management easy, you can also just specify an extension set.
-Both `markdownToHtml()` and `new Document()` accept an `extensionSet` named
-parameter. Right now there are two extension sets:
+Both `markdownToHtml()` and `Document()` accept an `extensionSet` named
+parameter. Currently, there are four pre-defined extension sets:
 
 * `ExtensionSet.none` includes no extensions. With no extensions, Markdown
-  documents will be parsed closely to how they might be parsed by the original
+  documents will be parsed with a default set of block and inline syntax
+  parsers that closely match how the document might be parsed by the original
   [Perl Markdown][] implementation.
-* `ExtensionSet.commonMark` includes two extensions so far, which bring this
-  package's Markdown parsing closer to what is found in the [CommonMark] spec:
 
-  * `new InlineHtmlSyntax()`
-  * `const FencedCodeBlockSyntax()`
+* `ExtensionSet.commonMark` includes two extensions in addition to the default
+  parsers to bring the parsed output closer to the [CommonMark] specification:
 
-* `ExtensionSet.gitHubWeb` includes seven extensions:
+  * Block Syntax Parser
+    * `const FencedCodeBlockSyntax()`
+  
+  * Inline Syntax Parser
+    * `InlineHtmlSyntax()`
 
-  * `new EmojiSyntax()`
-  * `new InlineHtmlSyntax()`
-  * `const HeaderWithIdSyntax()`, which adds `id` attributes to ATX-style
-    headers, for easy intra-document linking.
-  * `const SetextHeaderWithIdSyntax()`, which adds `id` attributes to
-    Setext-style headers, for easy intra-document linking.
-  * `const FencedCodeBlockSyntax()`
-  * `new StrikethroughSyntax()`
-  * `const TableSyntax()`
+* `ExtensionSet.gitHubFlavored` includes five extensions in addition to the default
+  parsers to bring the parsed output close to the [GitHub Flavored] Markdown
+  specification: 
+
+  * Block Syntax Parser
+    * `const FencedCodeBlockSyntax()`
+    * `const TableSyntax()`
+  
+  * Inline Syntax Parser
+    * `InlineHtmlSyntax()`
+    * `StrikethroughSyntax()`
+    * `AutolinkExtensionSyntax()`
+
+* `ExtensionSet.gitHubWeb` includes eight extensions. The same set of parsers use
+   in the `gitHubFlavored` extension set with the addition of the block syntax parsers,
+   HeaderWithIdSyntax and SetextHeaderWithIdSyntax, which add `id` attributes to
+   headers and inline syntac parser, EmojiSyntax, for parsing GitHub style emoji
+   characters:
+
+  * Block Syntax Parser
+    * `const FencedCodeBlockSyntax()`
+    * `const HeaderWithIdSyntax()`, which adds `id` attributes to ATX-style
+      headers, for easy intra-document linking.
+    * `const SetextHeaderWithIdSyntax()`, which adds `id` attributes to
+      Setext-style headers, for easy intra-document linking.
+    * `const TableSyntax()`
+  
+  * Inline Syntax Parser
+    * `InlineHtmlSyntax()`
+    * `StrikethroughSyntax()`
+    * `EmojiSyntax()`
+    * `AutolinkExtensionSyntax()`
 
 ### Custom syntax extensions
 
@@ -135,10 +161,11 @@ compliance with [CommonMark].
     Verify the updated links are still valid.
  5. Commit changes, including a corresponding note in `CHANGELOG.md`.
 
-[Perl Markdown]: http://daringfireball.net/projects/markdown/
-[CommonMark]: http://commonmark.org/
-[commonMark-raw-html]: http://spec.commonmark.org/0.28/#raw-html
+[Perl Markdown]: https://daringfireball.net/projects/markdown/
+[CommonMark]: https://commonmark.org/
+[commonMark-raw-html]: https://spec.commonmark.org/0.28/#raw-html
 [CommonMark source]: https://github.com/jgm/CommonMark/
-[pandoc-auto_identifiers]: http://pandoc.org/README.html#extension-auto_identifiers
+[GitHub Flavored]: https://github.github.com/gfm/
+[pandoc-auto_identifiers]: https://pandoc.org/README.html#extension-auto_identifiers
 ["Markdown's XSS Vulnerability (and how to mitigate it)"]: https://github.com/showdownjs/showdown/wiki/Markdown%27s-XSS-Vulnerability-(and-how-to-mitigate-it)
 [NodeValidator]: https://api.dart.dev/stable/dart-html/NodeValidator-class.html

--- a/lib/src/extension_set.dart
+++ b/lib/src/extension_set.dart
@@ -15,14 +15,21 @@ class ExtensionSet {
   /// fenced code blocks, or inline HTML.
   ///
   /// [Markdown.pl]: http://daringfireball.net/projects/markdown/syntax
-  static final ExtensionSet none = ExtensionSet([], []);
+  static final ExtensionSet none = ExtensionSet(
+    List<BlockSyntax>.unmodifiable(<BlockSyntax>[]),
+    List<InlineSyntax>.unmodifiable(<InlineSyntax>[]),
+  );
 
   /// The [commonMark] extension set is close to compliance with [CommonMark].
   ///
   /// [CommonMark]: http://commonmark.org/
   static final ExtensionSet commonMark = ExtensionSet(
-    [const FencedCodeBlockSyntax()],
-    [InlineHtmlSyntax()],
+    List<BlockSyntax>.unmodifiable(
+      <BlockSyntax>[const FencedCodeBlockSyntax()],
+    ),
+    List<InlineSyntax>.unmodifiable(
+      <InlineSyntax>[InlineHtmlSyntax()],
+    ),
   );
 
   /// The [gitHubWeb] extension set renders Markdown similarly to GitHub.
@@ -34,30 +41,44 @@ class ExtensionSet {
   /// linkable IDs.)
   ///
   /// [GitHub flavored Markdown]: https://github.github.com/gfm/
-  static final ExtensionSet gitHubWeb = ExtensionSet([
-    const FencedCodeBlockSyntax(),
-    const HeaderWithIdSyntax(),
-    const SetextHeaderWithIdSyntax(),
-    const TableSyntax()
-  ], [
-    InlineHtmlSyntax(),
-    StrikethroughSyntax(),
-    EmojiSyntax(),
-    AutolinkExtensionSyntax(),
-  ]);
+  static final ExtensionSet gitHubWeb = ExtensionSet(
+    List<BlockSyntax>.unmodifiable(
+      <BlockSyntax>[
+        const FencedCodeBlockSyntax(),
+        const HeaderWithIdSyntax(),
+        const SetextHeaderWithIdSyntax(),
+        const TableSyntax(),
+      ],
+    ),
+    List<InlineSyntax>.unmodifiable(
+      <InlineSyntax>[
+        InlineHtmlSyntax(),
+        StrikethroughSyntax(),
+        EmojiSyntax(),
+        AutolinkExtensionSyntax()
+      ],
+    ),
+  );
 
   /// The [gitHubFlavored] extension set is close to compliance with the [GitHub
   /// flavored Markdown spec].
   ///
   /// [GitHub flavored Markdown]: https://github.github.com/gfm/
-  static final ExtensionSet gitHubFlavored = ExtensionSet([
-    const FencedCodeBlockSyntax(),
-    const TableSyntax()
-  ], [
-    InlineHtmlSyntax(),
-    StrikethroughSyntax(),
-    AutolinkExtensionSyntax(),
-  ]);
+  static final ExtensionSet gitHubFlavored = ExtensionSet(
+    List<BlockSyntax>.unmodifiable(
+      <BlockSyntax>[
+        const FencedCodeBlockSyntax(),
+        const TableSyntax(),
+      ],
+    ),
+    List<InlineSyntax>.unmodifiable(
+      <InlineSyntax>[
+        InlineHtmlSyntax(),
+        StrikethroughSyntax(),
+        AutolinkExtensionSyntax()
+      ],
+    ),
+  );
 
   final List<BlockSyntax> blockSyntaxes;
   final List<InlineSyntax> inlineSyntaxes;


### PR DESCRIPTION
This corrects the README inaccuracies in the Extension sets section. More details could be added to this section but this PR addresses some of the omissions and inaccuracies and is an improvement over the existing information.