### PR TITLE
Prioritize custom inline syntax parsers

### DIFF
--- a/lib/src/inline_parser.dart
+++ b/lib/src/inline_parser.dart
@@ -81,17 +81,17 @@ class InlineParser {
       syntaxes.add(TextSyntax(r'[ \tA-Za-z0-9]*[A-Za-z0-9](?=\s)'));
     }
 
+    // Custom link resolvers go after the generic text syntax.
+    syntaxes.addAll([
+      LinkSyntax(linkResolver: document.linkResolver),
+      ImageSyntax(linkResolver: document.imageLinkResolver)
+    ]);
+
     syntaxes.addAll(_defaultSyntaxes);
 
     if (document.encodeHtml) {
       syntaxes.addAll(_htmlSyntaxes);
     }
-
-    // Custom link resolvers go after the generic text syntax.
-    syntaxes.insertAll(1, [
-      LinkSyntax(linkResolver: document.linkResolver),
-      ImageSyntax(linkResolver: document.imageLinkResolver)
-    ]);
   }
 
   List<Node> parse() {


### PR DESCRIPTION
Injecting the LinkSyntax and ImageSyntax parsers after the generic text syntax parser fixes problems when they are inserted at the fixed position index of 1 in the inline parser stack. When injected at index = 1, these parsers have the potential of interfering with custom parsers supplied with the document. By adding them after the generic text parser, the original intent for their inclusion in the stack is restored and they won't interfere with the custom parsers.

I tested this change against the blns_test, document_test, markdown_test, and version_test. All tests passed without errors.

Fixes #302 