### PR TITLE
Fixes for Issue 310 - Follow Dart file conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,9 +161,9 @@
 ## 0.11.0
 
 * Parse HTML blocks more accurately, according to
-  [CommonMark](http://spec.commonmark.org/0.24/#html-blocks).
+  [CommonMark](https://spec.commonmark.org/0.24/#html-blocks).
 * Support [shortcut reference
-  links](http://spec.commonmark.org/0.24/#reference-link).
+  links](https://spec.commonmark.org/0.24/#reference-link).
 * Don't allow an indented code block to interrupt a paragraph.
 * Change definition of "loose" and "strict" lists (items wrapped in
   paragraph tags vs not) to CommonMark's. The primary difference is that any
@@ -176,7 +176,7 @@
 
 ## 0.10.1
 
-* Parse [hard line breaks](http://spec.commonmark.org/0.24/#hard-line-breaks)
+* Parse [hard line breaks](https://spec.commonmark.org/0.24/#hard-line-breaks)
   properly (#86). Thanks @mehaase!
 * Fix processing of `[ ... ]` syntax when no resolver is specified (#92).
 * There are now 401/613 (65%) passing CommonMark v0.24 specs.

--- a/README.md
+++ b/README.md
@@ -157,14 +157,15 @@ compliance with [CommonMark].
 
  3. Update the stats files as described above. Note any changes in the results.
  4. Update any references to the existing spec by search for
-    `http://spec.commonmark.org/0.28` in the repository. (Including this one.)
+    `https://spec.commonmark.org/0.28` in the repository. (Including this one.)
     Verify the updated links are still valid.
  5. Commit changes, including a corresponding note in `CHANGELOG.md`.
 
-[Perl Markdown]: http://daringfireball.net/projects/markdown/
-[CommonMark]: http://commonmark.org/
-[commonMark-raw-html]: http://spec.commonmark.org/0.28/#raw-html
+[Perl Markdown]: https://daringfireball.net/projects/markdown/
+[CommonMark]: https://commonmark.org/
+[commonMark-raw-html]: https://spec.commonmark.org/0.28/#raw-html
 [CommonMark source]: https://github.com/jgm/CommonMark/
-[pandoc-auto_identifiers]: http://pandoc.org/README.html#extension-auto_identifiers
+[GitHub Flavored]: https://github.github.com/gfm/
+[pandoc-auto_identifiers]: https://pandoc.org/README.html#extension-auto_identifiers
 ["Markdown's XSS Vulnerability (and how to mitigate it)"]: https://github.com/showdownjs/showdown/wiki/Markdown%27s-XSS-Vulnerability-(and-how-to-mitigate-it)
 [NodeValidator]: https://api.dart.dev/stable/dart-html/NodeValidator-class.html

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,8 @@
 name: markdown
 version: 2.1.8
 
-description: A library for converting markdown to HTML.
+description: A portable Markdown library written in Dart that can parse
+ Markdown into HTML on both the client and server.
 homepage: https://github.com/dart-lang/markdown
 
 executables:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: markdown
 version: 2.1.8
 
 description: A portable Markdown library written in Dart that can parse
- Markdown into HTML on both the client and server.
+ Markdown into HTML.
 homepage: https://github.com/dart-lang/markdown
 
 executables:


### PR DESCRIPTION
Added a longer description of the markdown package to pubspec.yaml and fixed the links in the README.md and CHANGELOG.md files. This should increase the pub points for the markdown package by 20 points from 80/110 to 100/110.