### PR TITLE
Remove 4 public methods from public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.0.0-dev
+
+* **Breaking change:** Remove `ListSyntax.removeLeadingEmptyLine`,
+  `ListSyntax.removeTrailingEmptyLines`, `TableSyntax.parseAlignments`,
+  `TableSyntax.parseRow`.
+
 ## 2.1.8
 
 * Deprecate the _public_ methods `ListSyntax.removeLeadingEmptyLine`,

--- a/lib/src/block_parser.dart
+++ b/lib/src/block_parser.dart
@@ -801,11 +801,6 @@ abstract class ListSyntax extends BlockSyntax {
     }
   }
 
-  @Deprecated(
-      'Public method was intended to be private; will be removed in a major '
-      'version release, as early as markdown 3.0.0')
-  void removeLeadingEmptyLine(ListItem item) => _removeLeadingEmptyLine(item);
-
   /// Removes any trailing empty lines and notes whether any items are separated
   /// by such lines.
   bool _removeTrailingEmptyLines(List<ListItem> items) {
@@ -822,12 +817,6 @@ abstract class ListSyntax extends BlockSyntax {
     }
     return anyEmpty;
   }
-
-  @Deprecated(
-      'Public method was intended to be private; will be removed in a major '
-      'version release, as early as markdown 3.0.0')
-  bool removeTrailingEmptyLines(List<ListItem> items) =>
-      _removeTrailingEmptyLines(items);
 
   static int _expandedTabLength(String input) {
     var length = 0;
@@ -948,11 +937,6 @@ class TableSyntax extends BlockSyntax {
     }).toList();
   }
 
-  @Deprecated(
-      'Public method was intended to be private; will be removed in a major '
-      'version release, as early as markdown 3.0.0')
-  List<String> parseAlignments(String line) => _parseAlignments(line);
-
   /// Parses a table row at the current line into a table row element, with
   /// parsed table cells.
   ///
@@ -1025,13 +1009,6 @@ class TableSyntax extends BlockSyntax {
 
     return Element('tr', row);
   }
-
-  @Deprecated(
-      'Public method was intended to be private; will be removed in a major '
-      'version release, as early as markdown 3.0.0')
-  Element parseRow(
-          BlockParser parser, List<String> alignments, String cellType) =>
-      _parseRow(parser, alignments, cellType);
 
   /// Walks past whitespace in [line] starting at [index].
   ///

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '2.1.8';
+const packageVersion = '3.0.0-dev';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: markdown
-version: 2.1.8
+version: 3.0.0-dev
 
 description: A portable Markdown library written in Dart that can parse
  Markdown into HTML.


### PR DESCRIPTION
This is a breaking change, so I'm bumping the version to 3.0.0-dev.