### PR TITLE
Remove trailing space from paragraphs, headings, html blocks

### DIFF
--- a/lib/src/block_parser.dart
+++ b/lib/src/block_parser.dart
@@ -282,7 +282,7 @@ class SetextHeaderSyntax extends BlockSyntax {
       }
     }
 
-    var contents = UnparsedContent(lines.join('\n'));
+    var contents = UnparsedContent(lines.join('\n').trimRight());
 
     return Element(tag /*!*/, [contents]);
   }
@@ -587,7 +587,7 @@ class BlockTagBlockHtmlSyntax extends BlockHtmlSyntax {
       parser.advance();
     }
 
-    return Text(childLines.join('\n'));
+    return Text(childLines.join('\n').trimRight());
   }
 }
 
@@ -634,7 +634,7 @@ class LongBlockHtmlSyntax extends BlockHtmlSyntax {
     }
 
     parser.advance();
-    return Text(childLines.join('\n'));
+    return Text(childLines.join('\n').trimRight());
   }
 }
 
@@ -1094,7 +1094,7 @@ class ParagraphSyntax extends BlockSyntax {
       // Paragraph consisted solely of reference link definitions.
       return Text('');
     } else {
-      var contents = UnparsedContent(paragraphLines.join('\n'));
+      var contents = UnparsedContent(paragraphLines.join('\n').trimRight());
       return Element('p', [contents]);
     }
   }

--- a/test/common_mark/hard_line_breaks.unit
+++ b/test/common_mark/hard_line_breaks.unit
@@ -69,7 +69,7 @@ foo\
 >>> Hard line breaks - 642
 foo  
 <<<
-<p>foo  </p>
+<p>foo</p>
 >>> Hard line breaks - 643
 ### foo\
 <<<

--- a/test/common_mark/html_blocks.unit
+++ b/test/common_mark/html_blocks.unit
@@ -226,7 +226,6 @@ foo
   type="text/css">
 
 foo
-
 >>> HTML blocks - 143
 > <div>
 > foo

--- a/test/common_mark/paragraphs.unit
+++ b/test/common_mark/paragraphs.unit
@@ -56,4 +56,4 @@ aaa
 bbb     
 <<<
 <p>aaa<br />
-bbb     </p>
+bbb</p>

--- a/test/common_mark/setext_headings.unit
+++ b/test/common_mark/setext_headings.unit
@@ -20,7 +20,7 @@ baz*
 ====
 <<<
 <h1>  Foo <em>bar
-baz</em>	</h1>
+baz</em></h1>
 >>> Setext headings - 53
 Foo
 -------------------------
@@ -82,7 +82,7 @@ Foo
 Foo  
 -----
 <<<
-<h2>Foo  </h2>
+<h2>Foo</h2>
 >>> Setext headings - 60
 Foo\
 ----

--- a/test/gfm/hard_line_breaks.unit
+++ b/test/gfm/hard_line_breaks.unit
@@ -69,7 +69,7 @@ foo\
 >>> Hard line breaks - 666
 foo  
 <<<
-<p>foo  </p>
+<p>foo</p>
 >>> Hard line breaks - 667
 ### foo\
 <<<

--- a/test/gfm/html_blocks.unit
+++ b/test/gfm/html_blocks.unit
@@ -226,7 +226,6 @@ foo
   type="text/css">
 
 foo
-
 >>> HTML blocks - 143
 > <div>
 > foo

--- a/test/gfm/paragraphs.unit
+++ b/test/gfm/paragraphs.unit
@@ -56,4 +56,4 @@ aaa
 bbb     
 <<<
 <p>aaa<br />
-bbb     </p>
+bbb</p>

--- a/test/gfm/setext_headings.unit
+++ b/test/gfm/setext_headings.unit
@@ -20,7 +20,7 @@ baz*
 ====
 <<<
 <h1>  Foo <em>bar
-baz</em>	</h1>
+baz</em></h1>
 >>> Setext headings - 53
 Foo
 -------------------------
@@ -82,7 +82,7 @@ Foo
 Foo  
 -----
 <<<
-<h2>Foo  </h2>
+<h2>Foo</h2>
 >>> Setext headings - 60
 Foo\
 ----

--- a/tool/common_mark_stats.json
+++ b/tool/common_mark_stats.json
@@ -305,7 +305,7 @@
   "639": "strict",
   "640": "strict",
   "641": "strict",
-  "642": "loose",
+  "642": "strict",
   "643": "strict",
   "644": "strict"
  },
@@ -334,7 +334,7 @@
   "139": "strict",
   "140": "strict",
   "141": "strict",
-  "142": "loose",
+  "142": "strict",
   "143": "loose",
   "144": "loose",
   "145": "strict",
@@ -600,7 +600,7 @@
   "193": "strict",
   "194": "strict",
   "195": "strict",
-  "196": "loose"
+  "196": "strict"
  },
  "Precedence": {
   "12": "strict"
@@ -638,7 +638,7 @@
   "56": "strict",
   "57": "strict",
   "58": "strict",
-  "59": "loose",
+  "59": "strict",
   "60": "strict",
   "61": "loose",
   "62": "strict",

--- a/tool/common_mark_stats.txt
+++ b/tool/common_mark_stats.txt
@@ -25,4 +25,4 @@
    3 of    3 – 100.0%  Textual content
   19 of   19 – 100.0%  Thematic breaks
  603 of  649 –  92.9%  TOTAL
- 529 of  603 –  87.7%  TOTAL Strict
+ 533 of  603 –  88.4%  TOTAL Strict

--- a/tool/gfm_stats.json
+++ b/tool/gfm_stats.json
@@ -321,7 +321,7 @@
   "663": "strict",
   "664": "strict",
   "665": "strict",
-  "666": "loose",
+  "666": "strict",
   "667": "strict",
   "668": "strict"
  },
@@ -350,7 +350,7 @@
   "139": "strict",
   "140": "strict",
   "141": "strict",
-  "142": "loose",
+  "142": "strict",
   "143": "loose",
   "144": "loose",
   "145": "strict",
@@ -616,7 +616,7 @@
   "193": "strict",
   "194": "strict",
   "195": "strict",
-  "196": "loose"
+  "196": "strict"
  },
  "Precedence": {
   "12": "strict"
@@ -654,7 +654,7 @@
   "56": "strict",
   "57": "strict",
   "58": "strict",
-  "59": "loose",
+  "59": "strict",
   "60": "strict",
   "61": "loose",
   "62": "strict",

--- a/tool/gfm_stats.txt
+++ b/tool/gfm_stats.txt
@@ -29,4 +29,4 @@
    3 of    3 – 100.0%  Textual content
   19 of   19 – 100.0%  Thematic breaks
  618 of  671 –  92.1%  TOTAL
- 535 of  618 –  86.6%  TOTAL Strict
+ 539 of  618 –  87.2%  TOTAL Strict


### PR DESCRIPTION
Fixes #319 