### PR TITLE
Bump to 4.0.0-nullsafety.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 4.0.0-dev
+## 4.0.0-nullsafety.0
 
 * Migrate package to Dart's null safety language feature, requiring Dart
   2.12 or higher.

--- a/lib/src/emojis.dart
+++ b/lib/src/emojis.dart
@@ -2,7 +2,7 @@
 //
 // This file was generated from emojilib's emoji data file:
 // https://github.com/muan/emojilib/raw/master/emojis.json
-// at 2019-03-26 11:56:22.016973 by the script, tool/update_emojis.dart.
+// at 2021-01-06 07:39:39.063511 by the script, tool/update_emojis.dart.
 
 const emojis = <String, String>{
   'grinning': '😀',

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '4.0.0-dev';
+const packageVersion = '4.0.0-nullsafety.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: markdown
-version: 4.0.0-dev
+version: 4.0.0-nullsafety.0
 
 description: A portable Markdown library written in Dart that can parse
  Markdown into HTML.
@@ -20,10 +20,10 @@ dev_dependencies:
   build_runner: ^1.0.0
   build_version: ^2.0.0
   build_web_compilers: '>=1.0.0 <3.0.0'
-  collection: ^1.2.0
+  collection: ^1.15.0-nullsafety.5
   html: '>=0.12.2 <0.15.0'
   io: ^0.3.2+1
-  js: ^0.6.1
+  js: ^0.6.3-nullsafety.3
   path: ^1.8.0-nullsafety.3
   pedantic: ^1.10.0-nullsafety.3
   test: ^1.16.0-nullsafety.13

--- a/test/blns.dart
+++ b/test/blns.dart
@@ -2,7 +2,7 @@
 //
 // This file was generated from big-list-of-naughty-strings's JSON file:
 // https://github.com/minimaxir/big-list-of-naughty-strings/raw/master/blns.json
-// at 2020-05-27 21:54:09.623750 by the script, tool/update_blns.dart.
+// at 2021-01-06 07:39:31.000815 by the script, tool/update_blns.dart.
 
 const blns = <String>[
   '',


### PR DESCRIPTION
A few dev_dependencies are bumped to their nullsafety versions.

args cannot be bumped yet because test_core does not support the nullsafety version yet.

Fixes #351 