### PR TITLE
stable null safety release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
-## 4.0.0-dev
+## 4.0.0
 
-* Update `args` dep to allow the latest stable, update all `-nullsafety`
-  pre-release deps to depend on stable versions.
+* Stable null safety release.
+* Require the latest `args`, update the markdown executable to be opted in.
 
 ## 4.0.0-nullsafety.0
 

--- a/bin/markdown.dart
+++ b/bin/markdown.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @dart=2.9
-
 import 'dart:async';
 import 'dart:io';
 
@@ -60,7 +58,7 @@ Future<void> main(List<String> args) async {
 
   // Read from stdin.
   var buffer = StringBuffer();
-  String line;
+  String? line;
   while ((line = stdin.readLineSync()) != null) {
     buffer.writeln(line);
   }

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '4.0.0-dev';
+const packageVersion = '4.0.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: markdown
-version: 4.0.0-dev
+version: 4.0.0
 
 description: A portable Markdown library written in Dart that can parse
  Markdown into HTML.
@@ -12,7 +12,7 @@ environment:
   sdk: '>=2.12.0-0 <3.0.0'
 
 dependencies:
-  args: '>=1.0.0 <3.0.0'
+  args: ^2.0.0
   charcode: ^1.2.0
   meta: ^1.3.0
 
@@ -21,7 +21,7 @@ dev_dependencies:
   build_version: ^2.0.0
   build_web_compilers: '>=1.0.0 <3.0.0'
   collection: ^1.15.0
-  html: '>=0.12.2 <0.15.0'
+  html: ^0.15.0-nullsafety
   io: ^0.3.2+1
   js: ^0.6.3
   path: ^1.8.0

--- a/tool/dartdoc-compare.dart
+++ b/tool/dartdoc-compare.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @dart=2.9
-
 import 'dart:convert' show jsonEncode, jsonDecode;
 import 'dart:io' show Directory, File, Platform, Process, exitCode;
 
@@ -49,7 +47,7 @@ void main(List<String> arguments) {
       absolute(options[_dartdocDir] as String, 'pubspec.yaml'),
       options[_sdk] as bool);
 
-  String path;
+  String? path;
   if (comparer.sdk) {
     if (options.rest.isNotEmpty) {
       path = options.rest.single;
@@ -77,7 +75,7 @@ class DartdocCompare {
   DartdocCompare(this.dartdocDir, this.markdownBefore, this.markdownAfter,
       this.dartdocBin, this.dartdocPubspecPath, this.sdk);
 
-  bool compare(String package) {
+  bool compare(String? package) {
     // Generate docs with Markdown "Before".
     var outBefore = _runDartdoc(markdownBefore, package);
 
@@ -93,7 +91,7 @@ class DartdocCompare {
     return result.exitCode == 0;
   }
 
-  String _runDartdoc(String markdownRef, String path) {
+  String _runDartdoc(String markdownRef, String? path) {
     print('==========================================================');
     print('Running dartdoc for $markdownRef...');
     print('==========================================================');
@@ -159,7 +157,7 @@ int _system(String cmd, List<String> args) {
   return result.exitCode;
 }
 
-T _doInPath<T>(String path, T Function() f) {
+T _doInPath<T>(String? path, T Function() f) {
   if (path == null) {
     return f();
   }


### PR DESCRIPTION
This also requires the latest args now, and I opted in the markdown executable and any other files I could.

Some tests and tool scripts are still blocked on package:io.