### PR TITLE
Export `src/emojis.dart`

### DIFF
--- a/lib/markdown.dart
+++ b/lib/markdown.dart
@@ -10,6 +10,7 @@ import 'src/version.dart';
 export 'src/ast.dart';
 export 'src/block_parser.dart';
 export 'src/document.dart';
+export 'src/emojis.dart';
 export 'src/extension_set.dart';
 export 'src/html_renderer.dart';
 export 'src/inline_parser.dart';


### PR DESCRIPTION
As I mentioned in this issue: https://github.com/dart-lang/markdown/issues/376 , importing `src/emojis.dart` from the `markdown` package raising a warning.

This PR is to export `emojis.dart` by default so we can use them after importing the package with

```dart
import 'package:markdown/markdown.dart';
```
