### PR TITLE
Check parser.isDone when title is null in _parseInlineBracketedLink

### DIFF
--- a/lib/src/inline_parser.dart
+++ b/lib/src/inline_parser.dart
@@ -1201,7 +1201,8 @@ class LinkSyntax extends TagSyntax {
     var char = parser.charAt(parser.pos);
     if (char == $space || char == $lf || char == $cr || char == $ff) {
       var title = _parseTitle(parser);
-      if (title == null && parser.charAt(parser.pos) != $rparen) {
+      if (title == null &&
+          (parser.isDone || parser.charAt(parser.pos) != $rparen)) {
         // This looked like an inline link, until we found this $space
         // followed by mystery characters; no longer a link.
         return null;


### PR DESCRIPTION
It will throw an exception when it is an inline bracketed link and there is a backslash before the ending quote.

```dart
markdownToHtml(r'[url](<https://www> "title\")');
```

![Screenshot 2022-03-08 at 21 10 56](https://user-images.githubusercontent.com/5637609/157317298-147c2297-2440-40ad-8ece-208b4f76498e.png)

