### PR TITLE
Use `Uri.toFilePath()` instead of `Uri.path` for locating tests

### DIFF
--- a/test/util.dart
+++ b/test/util.dart
@@ -27,7 +27,7 @@ Future<void> testDirectory(String name, {ExtensionSet? extensionSet}) async {
 Future<String> get markdownPackageRoot async =>
     p.dirname(p.dirname((await Isolate.resolvePackageUri(
             Uri.parse('package:markdown/markdown.dart')))!
-        .path));
+        .toFilePath()));
 
 void testFile(
   String file, {

--- a/tool/expected_output.dart
+++ b/tool/expected_output.dart
@@ -119,7 +119,8 @@ Stream<DataCase> dataCasesUnder({
 }) async* {
   var markdownLibRoot = p.dirname((await Isolate.resolvePackageUri(
           Uri.parse('package:markdown/markdown.dart')))!
-      .path);
+      .toFilePath());
+
   var directory =
       p.joinAll([p.dirname(markdownLibRoot), 'test', testDirectory]);
   for (var dataCase in _dataCases(


### PR DESCRIPTION
When running the test suite on Windows all tests will fail with:

      Failed to load "test\markdown_test.dart": Directory listing failed, path = '/C:/Users/xxxxxxx/markdown\test\original\*' (OS Error: El nombre de archivo, el nombre de directorio o la sintaxis de la etiqueta del volumen no son correctos., errno = 123)

The important bit to notice is the path: `/C:/`..., the initial forward slash on the path results in an invalid path for Windows.

This can be tracked down to the two calls to `Uri.path`. It would be preferable to use `Uri.toFilePath()` which does take into account  Window's path formats.

You can see the different behaviour on [this dartpad](https://dartpad.dev/f5fa8437fc8fbf7454ef052527308deb).

This PR simply does the switch from `Uri.path` to `Uri.toFilePath()` resulting in tests working on windows.