### PR TITLE
Treat lines matched CodeBlockSyntx as continuations of paragraphs in blockquotes

### DIFF
--- a/lib/src/block_parser.dart
+++ b/lib/src/block_parser.dart
@@ -340,10 +340,13 @@ class BlockquoteSyntax extends BlockSyntax {
     // Grab all of the lines that form the blockquote, stripping off the ">".
     var childLines = <String>[];
 
+    bool encounteredCodeBlock = false;
     while (!parser.isDone) {
       var match = pattern.firstMatch(parser.current);
       if (match != null) {
-        childLines.add(match[1]!);
+        final line = match[1]!;
+        childLines.add(line);
+        encounteredCodeBlock = _indentPattern.hasMatch(line);
         parser.advance();
         continue;
       }
@@ -355,7 +358,8 @@ class BlockquoteSyntax extends BlockSyntax {
       // matched CodeBlockSyntx is also paragraph continuation text.
       final otherMatched =
           parser.blockSyntaxes.firstWhere((s) => s.canParse(parser));
-      if (otherMatched is ParagraphSyntax || otherMatched is CodeBlockSyntax) {
+      if (otherMatched is ParagraphSyntax ||
+          (!encounteredCodeBlock && otherMatched is CodeBlockSyntax)) {
         childLines.add(parser.current);
         parser.advance();
       } else {

--- a/lib/src/block_parser.dart
+++ b/lib/src/block_parser.dart
@@ -355,7 +355,7 @@ class BlockquoteSyntax extends BlockSyntax {
       // as any other syntax except Paragraph, and it doesn't match the bar in
       // a Setext header.
       // Because indented code blocks cannot interrupt paragraphs, a line
-      // matched CodeBlockSyntx is also paragraph continuation text.
+      // matched CodeBlockSyntax is also paragraph continuation text.
       final otherMatched =
           parser.blockSyntaxes.firstWhere((s) => s.canParse(parser));
       if (otherMatched is ParagraphSyntax ||

--- a/lib/src/block_parser.dart
+++ b/lib/src/block_parser.dart
@@ -351,8 +351,11 @@ class BlockquoteSyntax extends BlockSyntax {
       // A paragraph continuation is OK. This is content that cannot be parsed
       // as any other syntax except Paragraph, and it doesn't match the bar in
       // a Setext header.
-      if (parser.blockSyntaxes.firstWhere((s) => s.canParse(parser))
-          is ParagraphSyntax) {
+      // Because indented code blocks cannot interrupt paragraphs, a line
+      // matched CodeBlockSyntx is also paragraph continuation text.
+      final otherMatched =
+          parser.blockSyntaxes.firstWhere((s) => s.canParse(parser));
+      if (otherMatched is ParagraphSyntax || otherMatched is CodeBlockSyntax) {
         childLines.add(parser.current);
         parser.advance();
       } else {

--- a/test/common_mark/block_quotes.unit
+++ b/test/common_mark/block_quotes.unit
@@ -103,10 +103,9 @@ foo
     - bar
 <<<
 <blockquote>
-<p>foo</p>
+<p>foo
+- bar</p>
 </blockquote>
-<pre><code>- bar
-</code></pre>
 >>> Block quotes - 239
 >
 <<<

--- a/test/gfm/block_quotes.unit
+++ b/test/gfm/block_quotes.unit
@@ -103,10 +103,9 @@ foo
     - bar
 <<<
 <blockquote>
-<p>foo</p>
+<p>foo
+- bar</p>
 </blockquote>
-<pre><code>- bar
-</code></pre>
 >>> Block quotes - 217
 >
 <<<

--- a/tool/common_mark_stats.json
+++ b/tool/common_mark_stats.json
@@ -69,7 +69,7 @@
   "235": "strict",
   "236": "strict",
   "237": "fail",
-  "238": "fail",
+  "238": "strict",
   "239": "strict",
   "240": "strict",
   "241": "strict",

--- a/tool/common_mark_stats.txt
+++ b/tool/common_mark_stats.txt
@@ -2,7 +2,7 @@
   19 of   19 – 100.0%  Autolinks
   12 of   13 –  92.3%  Backslash escapes
    1 of    1 – 100.0%  Blank lines
-  22 of   25 –  88.0%  Block quotes
+  23 of   25 –  92.0%  Block quotes
   22 of   22 – 100.0%  Code spans
  130 of  131 –  99.2%  Emphasis and strong emphasis
   14 of   17 –  82.4%  Entity and numeric character references
@@ -24,5 +24,5 @@
   11 of   11 – 100.0%  Tabs
    3 of    3 – 100.0%  Textual content
   19 of   19 – 100.0%  Thematic breaks
- 613 of  652 –  94.0%  TOTAL
- 546 of  613 –  89.1%  TOTAL Strict
+ 614 of  652 –  94.2%  TOTAL
+ 547 of  614 –  89.1%  TOTAL Strict

--- a/tool/gfm_stats.json
+++ b/tool/gfm_stats.json
@@ -82,7 +82,7 @@
   "213": "strict",
   "214": "strict",
   "215": "fail",
-  "216": "fail",
+  "216": "strict",
   "217": "strict",
   "218": "strict",
   "219": "strict",

--- a/tool/gfm_stats.txt
+++ b/tool/gfm_stats.txt
@@ -3,7 +3,7 @@
    7 of   11 –  63.6%  Autolinks (extension)
   12 of   13 –  92.3%  Backslash escapes
    1 of    1 – 100.0%  Blank lines
-  22 of   25 –  88.0%  Block quotes
+  23 of   25 –  92.0%  Block quotes
   22 of   22 – 100.0%  Code spans
    0 of    1 –   0.0%  Disallowed Raw HTML (extension)
  130 of  131 –  99.2%  Emphasis and strong emphasis
@@ -28,5 +28,5 @@
   11 of   11 – 100.0%  Tabs
    3 of    3 – 100.0%  Textual content
   19 of   19 – 100.0%  Thematic breaks
- 625 of  671 –  93.1%  TOTAL
- 550 of  625 –  88.0%  TOTAL Strict
+ 626 of  671 –  93.3%  TOTAL
+ 551 of  626 –  88.0%  TOTAL Strict


### PR DESCRIPTION
Fix: https://github.com/dart-lang/markdown/issues/358