### PR TITLE
Do not allow reference link labels contain left brackets

### DIFF
--- a/lib/src/inline_parser.dart
+++ b/lib/src/inline_parser.dart
@@ -1118,6 +1118,8 @@ class LinkSyntax extends TagSyntax {
           buffer.writeCharCode(char);
         }
         buffer.writeCharCode(next);
+      } else if (char == $lbracket) {
+        return null;
       } else if (char == $rbracket) {
         break;
       } else {

--- a/test/common_mark/links.unit
+++ b/test/common_mark/links.unit
@@ -321,7 +321,7 @@ bar>)</p>
 
 [ref[]: /uri
 <<<
-<p><a href="/uri">foo</a></p>
+<p>[foo][ref[]</p>
 >>> Links - 546
 [foo][ref[bar]]
 

--- a/test/gfm/links.unit
+++ b/test/gfm/links.unit
@@ -309,7 +309,7 @@ bar>)</p>
 
 [ref[]: /uri
 <<<
-<p><a href="/uri">foo</a></p>
+<p>[foo][ref[]</p>
 >>> Links - 555
 [foo][ref[bar]]
 


### PR DESCRIPTION
Fix: https://github.com/dart-lang/markdown/issues/335