### PR TITLE
Support GitLab flavored fenced blockquote

### DIFF
--- a/test/extensions/fenced_blockquotes.unit
+++ b/test/extensions/fenced_blockquotes.unit
@@ -1,0 +1,70 @@
+>>> simple block quote
+>>>
+# Foo
+bar
+baz
+>>>
+
+<<<
+<blockquote>
+<h1>Foo</h1>
+<p>bar
+baz</p>
+</blockquote>
+>>> has blank lines
+>>>
+
+foo
+
+
+
+
+bar
+
+
+>>>
+
+<<<
+<blockquote>
+<p>foo</p>
+<p>bar</p>
+</blockquote>
+>>> with nested block quote
+>>>
+foo
+> bar
+>>>
+
+<<<
+<blockquote>
+<p>foo</p>
+<blockquote>
+<p>bar</p>
+</blockquote>
+</blockquote>
+>>> with nested indented clode block
+>>>
+    foo
+    bar
+>>>
+
+<<<
+<blockquote>
+<pre><code>foo
+bar
+</code></pre>
+</blockquote>
+>>> with nested fenced clode block
+>>>
+```
+foo
+bar
+```
+>>>
+
+<<<
+<blockquote>
+<pre><code>foo
+bar
+</code></pre>
+</blockquote>

--- a/test/markdown_test.dart
+++ b/test/markdown_test.dart
@@ -18,6 +18,8 @@ void main() async {
   testFile('extensions/setext_headers_with_ids.unit',
       blockSyntaxes: [const SetextHeaderWithIdSyntax()]);
   testFile('extensions/tables.unit', blockSyntaxes: [const TableSyntax()]);
+  testFile('extensions/fenced_blockquotes.unit',
+      blockSyntaxes: [const FencedBlockquoteSyntax()]);
 
   // Inline syntax extensions
   testFile('extensions/emojis.unit', inlineSyntaxes: [EmojiSyntax()]);


### PR DESCRIPTION
Fixes: https://github.com/dart-lang/markdown/issues/359

# How to use

```dart
const text = '>>>\nHello\n\nWorld!\n>>>';

final result = markdownToHtml(text, blockSyntaxes: [
  const FencedBlockquoteSyntax(),
]);
```