### PR TITLE
Add options to disable default syntaxes

### DIFF
--- a/lib/src/block_parser.dart
+++ b/lib/src/block_parser.dart
@@ -1233,7 +1233,7 @@ class ParagraphSyntax extends BlockSyntax {
   }
 }
 
-/// Walks the parser forward through the lines do not match any [BlockSyntax].
+/// Walks the parser forward through the lines does not match any [BlockSyntax].
 ///
 /// Returns a [UnparsedContent] with the unmatched lines as `textContent`.
 class DummyBlockSyntax extends BlockSyntax {

--- a/lib/src/block_parser.dart
+++ b/lib/src/block_parser.dart
@@ -101,7 +101,12 @@ class BlockParser {
 
   BlockParser(this.lines, this.document) {
     blockSyntaxes.addAll(document.blockSyntaxes);
-    blockSyntaxes.addAll(standardBlockSyntaxes);
+
+    if (document.withDefaultBlockSyntaxes) {
+      blockSyntaxes.addAll(standardBlockSyntaxes);
+    } else {
+      blockSyntaxes.add(const DummyBlockSyntax());
+    }
   }
 
   /// Gets the current line.
@@ -1225,5 +1230,33 @@ class ParagraphSyntax extends BlockSyntax {
     parser.document.linkReferences
         .putIfAbsent(label, () => LinkReference(label, destination, title));
     return true;
+  }
+}
+
+/// Walks the parser forward through the lines do not match any [BlockSyntax].
+///
+/// Returns a [UnparsedContent] with the unmatched lines as `textContent`.
+class DummyBlockSyntax extends BlockSyntax {
+  const DummyBlockSyntax();
+
+  @override
+  RegExp get pattern => _dummyPattern;
+
+  @override
+  bool canEndBlock(BlockParser parser) => false;
+
+  @override
+  bool canParse(BlockParser parser) => true;
+
+  @override
+  Node parse(BlockParser parser) {
+    final childLines = <String>[];
+
+    while (!BlockSyntax.isAtBlockEnd(parser)) {
+      childLines.add(parser.current);
+      parser.advance();
+    }
+
+    return UnparsedContent(childLines.join('\n'));
   }
 }

--- a/lib/src/document.dart
+++ b/lib/src/document.dart
@@ -14,10 +14,10 @@ class Document {
   final Resolver? imageLinkResolver;
   final bool encodeHtml;
 
-  /// Whether to have default block syntaxes.
+  /// Whether to use default block syntaxes.
   final bool withDefaultBlockSyntaxes;
 
-  /// Whether to have default inline syntaxes.
+  /// Whether to use default inline syntaxes.
   ///
   /// Need to set both [withDefaultInlineSyntaxes] and [encodeHtml] to
   /// `false` to disable all inline syntaxes including html encoding syntaxes.
@@ -25,7 +25,7 @@ class Document {
 
   final _blockSyntaxes = <BlockSyntax>{};
   final _inlineSyntaxes = <InlineSyntax>{};
-  late final bool hasCustomInlineSyntaxes;
+  final bool hasCustomInlineSyntaxes;
 
   Iterable<BlockSyntax> get blockSyntaxes => _blockSyntaxes;
 
@@ -40,22 +40,16 @@ class Document {
     this.encodeHtml = true,
     this.withDefaultBlockSyntaxes = true,
     this.withDefaultInlineSyntaxes = true,
-  }) {
-    hasCustomInlineSyntaxes = inlineSyntaxes?.isNotEmpty == true ||
-        extensionSet?.inlineSyntaxes.isNotEmpty == true;
-
+  }) : hasCustomInlineSyntaxes = (inlineSyntaxes?.isNotEmpty ?? false) ||
+            (extensionSet?.inlineSyntaxes.isNotEmpty ?? false) {
     _blockSyntaxes.addAll(blockSyntaxes ?? []);
     _inlineSyntaxes.addAll(inlineSyntaxes ?? []);
 
     if (extensionSet == null) {
-      // Add blockSyntaxes of ExtensionSet.commonMark by default if
-      // withDefaultBlockSyntaxes is true
       if (withDefaultBlockSyntaxes) {
         _blockSyntaxes.addAll(ExtensionSet.commonMark.blockSyntaxes);
       }
 
-      // Add inlineSyntaxes of ExtensionSet.commonMark by default if
-      // withDefaultInlineSyntaxes is true
       if (withDefaultInlineSyntaxes) {
         _inlineSyntaxes.addAll(ExtensionSet.commonMark.inlineSyntaxes);
       }

--- a/lib/src/document.dart
+++ b/lib/src/document.dart
@@ -10,12 +10,22 @@ import 'inline_parser.dart';
 /// Maintains the context needed to parse a Markdown document.
 class Document {
   final Map<String, LinkReference> linkReferences = <String, LinkReference>{};
-  final ExtensionSet extensionSet;
   final Resolver? linkResolver;
   final Resolver? imageLinkResolver;
   final bool encodeHtml;
+
+  /// Whether to have default block syntaxes.
+  final bool withDefaultBlockSyntaxes;
+
+  /// Whether to have default inline syntaxes.
+  ///
+  /// Need to set both [withDefaultInlineSyntaxes] and [encodeHtml] to
+  /// `false` to disable all inline syntaxes including html encoding syntaxes.
+  final bool withDefaultInlineSyntaxes;
+
   final _blockSyntaxes = <BlockSyntax>{};
   final _inlineSyntaxes = <InlineSyntax>{};
+  late final bool hasCustomInlineSyntaxes;
 
   Iterable<BlockSyntax> get blockSyntaxes => _blockSyntaxes;
 
@@ -28,13 +38,31 @@ class Document {
     this.linkResolver,
     this.imageLinkResolver,
     this.encodeHtml = true,
-  }) : extensionSet = extensionSet ?? ExtensionSet.commonMark {
-    _blockSyntaxes
-      ..addAll(blockSyntaxes ?? [])
-      ..addAll(this.extensionSet.blockSyntaxes);
-    _inlineSyntaxes
-      ..addAll(inlineSyntaxes ?? [])
-      ..addAll(this.extensionSet.inlineSyntaxes);
+    this.withDefaultBlockSyntaxes = true,
+    this.withDefaultInlineSyntaxes = true,
+  }) {
+    hasCustomInlineSyntaxes = inlineSyntaxes?.isNotEmpty == true ||
+        extensionSet?.inlineSyntaxes.isNotEmpty == true;
+
+    _blockSyntaxes.addAll(blockSyntaxes ?? []);
+    _inlineSyntaxes.addAll(inlineSyntaxes ?? []);
+
+    if (extensionSet == null) {
+      // Add blockSyntaxes of ExtensionSet.commonMark by default if
+      // withDefaultBlockSyntaxes is true
+      if (withDefaultBlockSyntaxes) {
+        _blockSyntaxes.addAll(ExtensionSet.commonMark.blockSyntaxes);
+      }
+
+      // Add inlineSyntaxes of ExtensionSet.commonMark by default if
+      // withDefaultInlineSyntaxes is true
+      if (withDefaultInlineSyntaxes) {
+        _inlineSyntaxes.addAll(ExtensionSet.commonMark.inlineSyntaxes);
+      }
+    } else {
+      _blockSyntaxes.addAll(extensionSet.blockSyntaxes);
+      _inlineSyntaxes.addAll(extensionSet.inlineSyntaxes);
+    }
   }
 
   /// Parses the given [lines] of Markdown to a series of AST nodes.

--- a/lib/src/html_renderer.dart
+++ b/lib/src/html_renderer.dart
@@ -19,6 +19,9 @@ String markdownToHtml(
   Resolver? linkResolver,
   Resolver? imageLinkResolver,
   bool inlineOnly = false,
+  bool? encodeHtml,
+  bool? withDefaultBlockSyntaxes,
+  bool? withDefaultInlineSyntaxes,
 }) {
   var document = Document(
     blockSyntaxes: blockSyntaxes,
@@ -26,6 +29,9 @@ String markdownToHtml(
     extensionSet: extensionSet,
     linkResolver: linkResolver,
     imageLinkResolver: imageLinkResolver,
+    encodeHtml: encodeHtml ?? true,
+    withDefaultBlockSyntaxes: withDefaultBlockSyntaxes ?? true,
+    withDefaultInlineSyntaxes: withDefaultInlineSyntaxes ?? true,
   );
 
   if (inlineOnly) return renderToHtml(document.parseInline(markdown));

--- a/lib/src/html_renderer.dart
+++ b/lib/src/html_renderer.dart
@@ -19,9 +19,9 @@ String markdownToHtml(
   Resolver? linkResolver,
   Resolver? imageLinkResolver,
   bool inlineOnly = false,
-  bool? encodeHtml,
-  bool? withDefaultBlockSyntaxes,
-  bool? withDefaultInlineSyntaxes,
+  bool encodeHtml = true,
+  bool withDefaultBlockSyntaxes = true,
+  bool withDefaultInlineSyntaxes = true,
 }) {
   var document = Document(
     blockSyntaxes: blockSyntaxes,
@@ -29,9 +29,9 @@ String markdownToHtml(
     extensionSet: extensionSet,
     linkResolver: linkResolver,
     imageLinkResolver: imageLinkResolver,
-    encodeHtml: encodeHtml ?? true,
-    withDefaultBlockSyntaxes: withDefaultBlockSyntaxes ?? true,
-    withDefaultInlineSyntaxes: withDefaultInlineSyntaxes ?? true,
+    encodeHtml: encodeHtml,
+    withDefaultBlockSyntaxes: withDefaultBlockSyntaxes,
+    withDefaultInlineSyntaxes: withDefaultInlineSyntaxes,
   );
 
   if (inlineOnly) return renderToHtml(document.parseInline(markdown));

--- a/test/html_renderer_test.dart
+++ b/test/html_renderer_test.dart
@@ -1,0 +1,80 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:markdown/markdown.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('markdownToHtml', () {
+    const text = '# Hello **Markdown<em>!</em>**\n***';
+
+    test('with no syntaxes', () {
+      final result = markdownToHtml(
+        text,
+        withDefaultBlockSyntaxes: false,
+        withDefaultInlineSyntaxes: false,
+        encodeHtml: false,
+      );
+      expect(result, equals('# Hello **Markdown<em>!</em>**\n***\n'));
+    });
+
+    test('with no default syntaxes but with custom syntaxes', () {
+      final result = markdownToHtml(
+        text,
+        withDefaultBlockSyntaxes: false,
+        withDefaultInlineSyntaxes: false,
+        encodeHtml: false,
+        blockSyntaxes: [const HorizontalRuleSyntax()],
+        inlineSyntaxes: [TagSyntax(r'\*+', requiresDelimiterRun: true)],
+      );
+
+      expect(
+        result,
+        equals('# Hello <strong>Markdown<em>!</em></strong>\n<hr />\n'),
+      );
+    });
+
+    test('with only default block syntaxes', () {
+      final result = markdownToHtml(
+        text,
+        withDefaultBlockSyntaxes: true,
+        withDefaultInlineSyntaxes: false,
+        encodeHtml: false,
+      );
+
+      expect(
+        result,
+        equals('<h1>Hello **Markdown<em>!</em>**</h1>\n<hr />\n'),
+      );
+    });
+
+    test('with only default inline syntaxes', () {
+      final result = markdownToHtml(
+        text,
+        withDefaultBlockSyntaxes: false,
+        withDefaultInlineSyntaxes: true,
+        encodeHtml: false,
+      );
+
+      expect(
+        result,
+        equals('# Hello <strong>Markdown<em>!</em></strong>\n***\n'),
+      );
+    });
+
+    test('with no default syntaxes but with encodeHtml enabled', () {
+      final result = markdownToHtml(
+        text,
+        withDefaultBlockSyntaxes: false,
+        withDefaultInlineSyntaxes: false,
+        encodeHtml: true,
+      );
+
+      expect(
+        result,
+        equals('# Hello **Markdown&lt;em&gt;!&lt;/em&gt;**\n***\n'),
+      );
+    });
+  });
+}


### PR DESCRIPTION
Fixes: https://github.com/dart-lang/markdown/issues/393

## Example

```dart
const text = '<center><a>**some text**</a></center>';

final result = markdownToHtml(
  text,
  withDefaultInlineSyntaxes: false,
  withDefaultBlockSyntaxes: false,
  encodeHtml: false,
  inlineSyntaxes: [
    TagSyntax(r'\*+', requiresDelimiterRun: true),
  ],
);

print(result);
```