### PR TITLE
Proposal: AST enhancement

### DIFF
--- a/lib/src/ast.dart
+++ b/lib/src/ast.dart
@@ -71,33 +71,26 @@ class Element implements Node {
 
 class Helper implements Node {
   /// Instantiates a marker [tag] Helper.
-  Helper.marker(String name, String marker)
+  Helper.marker(String marker)
       : tag = 'marker',
-        textContent = marker,
-        attributes = {
-          'name': name,
-        };
+        textContent = marker;
 
   /// Instantiates a whitespace [tag] Helper.
   Helper.whitespace(String whitespace)
       : tag = 'whitespace',
-        textContent = whitespace,
-        attributes = {};
+        textContent = whitespace;
 
   /// Instantiates an empty line [tag] Helper
   Helper.emptyLine(String? content)
       : tag = 'emptyline',
-        textContent = content ?? '',
-        attributes = {};
+        textContent = content ?? '';
 
   /// Instantiates an new line [tag] Helper
   Helper.newLine()
       : tag = 'newline',
-        textContent = '\n',
-        attributes = {};
+        textContent = '\n';
 
   final String tag;
-  final Map<String, String> attributes;
 
   @override
   void accept(NodeVisitor visitor) => visitor.visitHelper(this);

--- a/lib/src/ast.dart
+++ b/lib/src/ast.dart
@@ -55,8 +55,55 @@ class Element implements Node {
 
   @override
   String get textContent {
-    return (children ?? []).map((child) => child.textContent).join('');
+    return (children ?? [])
+        .map((child) => child is Helper ? '' : child.textContent)
+        .join('');
   }
+
+  /// If an Element has children other than Helpers.
+  bool hasContent() {
+    if (children == null || children!.isEmpty) {
+      return false;
+    }
+    return children!.whereType<Helper>().length != children!.length;
+  }
+}
+
+class Helper implements Node {
+  /// Instantiates a marker [tag] Helper.
+  Helper.marker(String name, String marker)
+      : tag = 'marker',
+        textContent = marker,
+        attributes = {
+          'name': name,
+        };
+
+  /// Instantiates a whitespace [tag] Helper.
+  Helper.whitespace(String whitespace)
+      : tag = 'whitespace',
+        textContent = whitespace,
+        attributes = {};
+
+  /// Instantiates an empty line [tag] Helper
+  Helper.emptyLine(String? content)
+      : tag = 'emptyline',
+        textContent = content ?? '',
+        attributes = {};
+
+  /// Instantiates an new line [tag] Helper
+  Helper.newLine()
+      : tag = 'newline',
+        textContent = '\n',
+        attributes = {};
+
+  final String tag;
+  final Map<String, String> attributes;
+
+  @override
+  void accept(NodeVisitor visitor) => visitor.visitHelper(this);
+
+  @override
+  final String textContent;
 }
 
 /// A plain text element.
@@ -94,6 +141,9 @@ class UnparsedContent implements Node {
 abstract class NodeVisitor {
   /// Called when a Text node has been reached.
   void visitText(Text text);
+
+  /// Called when a Helper node has been reached.
+  void visitHelper(Helper helper);
 
   /// Called when an Element has been reached, before its children have been
   /// visited.

--- a/lib/src/block_parser.dart
+++ b/lib/src/block_parser.dart
@@ -104,7 +104,7 @@ class BlockParser {
   bool get isDone => _pos >= lines.length;
 
   /// Gets whether or not the current line matches the given pattern.
-  bool matches(RegExp regex) {
+  bool matchesCurrent(RegExp regex) {
     if (isDone) return false;
     return regex.hasMatch(current);
   }
@@ -128,5 +128,25 @@ class BlockParser {
     }
 
     return blocks;
+  }
+
+  /// Whether has a match in the string [input] with the currrent [syntax].
+  bool canMatch(String input, BlockSyntax syntax) =>
+      syntax.pattern.hasMatch(input);
+
+  /// Whether `patternWithHelper` of current [syntax] is being used.
+  ///
+  /// Returns `true` if `patternWithHelper` of [syntax] is not `null` and
+  /// `withHelper` of [document] is true.
+  bool isHelperPatternActive(BlockSyntax syntax) =>
+      document.withHelper && syntax.patternWithHelper != null;
+
+  /// Tries to match the string [input] with the active pattern of [syntax].
+  RegExpMatch? matches(String input, BlockSyntax syntax) {
+    final pattern = !isHelperPatternActive(syntax)
+        ? syntax.pattern
+        : syntax.patternWithHelper!;
+
+    return pattern.firstMatch(input);
   }
 }

--- a/lib/src/block_syntaxes/block_syntax.dart
+++ b/lib/src/block_syntaxes/block_syntax.dart
@@ -11,10 +11,12 @@ abstract class BlockSyntax {
   /// Gets the regex used to identify the beginning of this block, if any.
   RegExp get pattern;
 
+  RegExp? get patternWithHelper => null;
+
   bool canEndBlock(BlockParser parser) => true;
 
   bool canParse(BlockParser parser) {
-    return pattern.hasMatch(parser.current);
+    return parser.canMatch(parser.current, this);
   }
 
   Node? parse(BlockParser parser);

--- a/lib/src/block_syntaxes/block_syntax.dart
+++ b/lib/src/block_syntaxes/block_syntax.dart
@@ -41,10 +41,9 @@ abstract class BlockSyntax {
   }
 
   /// Generates a valid HTML anchor from the inner text of [element].
-  static String generateAnchorHash(Element element) =>
-      element.children!.first.textContent
-          .toLowerCase()
-          .trim()
-          .replaceAll(RegExp('[^a-z0-9 _-]'), '')
-          .replaceAll(RegExp(r'\s'), '-');
+  static String generateAnchorHash(Element element) => element.textContent
+      .toLowerCase()
+      .trim()
+      .replaceAll(RegExp('[^a-z0-9 _-]'), '')
+      .replaceAll(RegExp(r'\s'), '-');
 }

--- a/lib/src/block_syntaxes/block_syntax.dart
+++ b/lib/src/block_syntaxes/block_syntax.dart
@@ -19,20 +19,6 @@ abstract class BlockSyntax {
 
   Node? parse(BlockParser parser);
 
-  List<String?> parseChildLines(BlockParser parser) {
-    // Grab all of the lines that form the block element.
-    final childLines = <String?>[];
-
-    while (!parser.isDone) {
-      final match = pattern.firstMatch(parser.current);
-      if (match == null) break;
-      childLines.add(match[1]);
-      parser.advance();
-    }
-
-    return childLines;
-  }
-
   /// Gets whether or not [parser]'s current line should end the previous block.
   static bool isAtBlockEnd(BlockParser parser) {
     if (parser.isDone) return true;

--- a/lib/src/block_syntaxes/block_tag_block_html_syntax.dart
+++ b/lib/src/block_syntaxes/block_tag_block_html_syntax.dart
@@ -39,7 +39,7 @@ class BlockTagBlockHtmlSyntax extends BlockHtmlSyntax {
     final childLines = <String>[];
 
     // Eat until we hit a blank line.
-    while (!parser.isDone && !parser.matches(emptyPattern)) {
+    while (!parser.isDone && !parser.matchesCurrent(emptyPattern)) {
       childLines.add(parser.current);
       parser.advance();
     }

--- a/lib/src/block_syntaxes/blockquote_syntax.dart
+++ b/lib/src/block_syntaxes/blockquote_syntax.dart
@@ -16,7 +16,6 @@ class BlockquoteSyntax extends BlockSyntax {
 
   const BlockquoteSyntax();
 
-  @override
   List<String> parseChildLines(BlockParser parser) {
     // Grab all of the lines that form the blockquote, stripping off the ">".
     final childLines = <String>[];

--- a/lib/src/block_syntaxes/code_block_syntax.dart
+++ b/lib/src/block_syntaxes/code_block_syntax.dart
@@ -18,7 +18,6 @@ class CodeBlockSyntax extends BlockSyntax {
 
   const CodeBlockSyntax();
 
-  @override
   List<String?> parseChildLines(BlockParser parser) {
     final childLines = <String?>[];
 

--- a/lib/src/block_syntaxes/fenced_blockquote_syntax.dart
+++ b/lib/src/block_syntaxes/fenced_blockquote_syntax.dart
@@ -14,7 +14,6 @@ class FencedBlockquoteSyntax extends BlockSyntax {
   @override
   RegExp get pattern => blockquoteFencePattern;
 
-  @override
   List<String> parseChildLines(BlockParser parser) {
     final childLines = <String>[];
     parser.advance();

--- a/lib/src/block_syntaxes/fenced_code_block_syntax.dart
+++ b/lib/src/block_syntaxes/fenced_code_block_syntax.dart
@@ -32,7 +32,6 @@ class FencedCodeBlockSyntax extends BlockSyntax {
         !infoString!.codeUnits.contains($backquote));
   }
 
-  @override
   List<String> parseChildLines(BlockParser parser, [String? endBlock]) {
     endBlock ??= '';
 

--- a/lib/src/block_syntaxes/header_syntax.dart
+++ b/lib/src/block_syntaxes/header_syntax.dart
@@ -18,8 +18,19 @@ class HeaderSyntax extends BlockSyntax {
   Node parse(BlockParser parser) {
     final match = pattern.firstMatch(parser.current)!;
     parser.advance();
-    final level = match[1]!.length;
-    final contents = UnparsedContent(match[2]!.trim());
-    return Element('h$level', [contents]);
+
+    final marker = match[2]!;
+    final level = marker.length;
+    final contents = UnparsedContent(match[4]!);
+
+    return Element('h$level', [
+      if (match[1]!.isNotEmpty) Helper.whitespace(match[1]!),
+      Helper.marker(marker),
+      if (match[3]!.isNotEmpty) Helper.whitespace(match[3]!),
+      contents,
+      if (match[5]!.isNotEmpty) Helper.whitespace(match[5]!),
+      if (match[6]!.isNotEmpty) Helper.marker(match[6]!),
+      if (!parser.isDone) Helper.newLine(),
+    ]);
   }
 }

--- a/lib/src/block_syntaxes/long_block_html_syntax.dart
+++ b/lib/src/block_syntaxes/long_block_html_syntax.dart
@@ -25,7 +25,7 @@ class LongBlockHtmlSyntax extends BlockHtmlSyntax {
     // Eat until we hit [endPattern].
     while (!parser.isDone) {
       childLines.add(parser.current);
-      if (parser.matches(_endPattern)) break;
+      if (parser.matchesCurrent(_endPattern)) break;
       parser.advance();
     }
 

--- a/lib/src/document.dart
+++ b/lib/src/document.dart
@@ -25,6 +25,10 @@ class Document {
   /// `false` to disable all inline syntaxes including html encoding syntaxes.
   final bool withDefaultInlineSyntaxes;
 
+  /// Whether to parse helper information such as markers and whitespaces as
+  /// AST nodes.
+  final bool withHelper;
+
   final _blockSyntaxes = <BlockSyntax>{};
   final _inlineSyntaxes = <InlineSyntax>{};
   final bool hasCustomInlineSyntaxes;
@@ -42,6 +46,7 @@ class Document {
     this.encodeHtml = true,
     this.withDefaultBlockSyntaxes = true,
     this.withDefaultInlineSyntaxes = true,
+    this.withHelper = false,
   }) : hasCustomInlineSyntaxes = (inlineSyntaxes?.isNotEmpty ?? false) ||
             (extensionSet?.inlineSyntaxes.isNotEmpty ?? false) {
     _blockSyntaxes.addAll(blockSyntaxes ?? []);

--- a/lib/src/html_renderer.dart
+++ b/lib/src/html_renderer.dart
@@ -119,6 +119,9 @@ class HtmlRenderer implements NodeVisitor {
   }
 
   @override
+  void visitHelper(Helper helper) {}
+
+  @override
   bool visitElementBefore(Element element) {
     // Hackish. Separate block-level elements with newlines.
     if (buffer.isNotEmpty && _blockTags.contains(element.tag)) {
@@ -160,8 +163,7 @@ class HtmlRenderer implements NodeVisitor {
   void visitElementAfter(Element element) {
     assert(identical(_elementStack.last, element));
 
-    if (element.children != null &&
-        element.children!.isNotEmpty &&
+    if (element.hasContent() &&
         _blockTags.contains(_lastVisitedTag) &&
         _blockTags.contains(element.tag)) {
       buffer.writeln();

--- a/lib/src/inline_parser.dart
+++ b/lib/src/inline_parser.dart
@@ -99,7 +99,7 @@ class InlineParser {
       syntaxes.addAll(_defaultSyntaxes);
     }
 
-    if (encodeHtml) {
+    if (document.encodeHtml) {
       syntaxes.addAll(_htmlSyntaxes);
     }
   }
@@ -358,6 +358,4 @@ class InlineParser {
     pos += length;
     start = pos;
   }
-
-  bool get encodeHtml => document.encodeHtml;
 }

--- a/lib/src/inline_syntaxes/autolink_extension_syntax.dart
+++ b/lib/src/inline_syntaxes/autolink_extension_syntax.dart
@@ -115,7 +115,7 @@ class AutolinkExtensionSyntax extends InlineSyntax {
       href = 'http://$href';
     }
 
-    final text = parser.encodeHtml ? escapeHtml(url) : url;
+    final text = parser.document.encodeHtml ? escapeHtml(url) : url;
     final anchor = Element.text('a', text);
     anchor.attributes['href'] = Uri.encodeFull(href);
     parser.addNode(anchor);

--- a/lib/src/inline_syntaxes/autolink_syntax.dart
+++ b/lib/src/inline_syntaxes/autolink_syntax.dart
@@ -14,7 +14,7 @@ class AutolinkSyntax extends InlineSyntax {
   @override
   bool onMatch(InlineParser parser, Match match) {
     final url = match[1]!;
-    final text = parser.encodeHtml ? escapeHtml(url) : url;
+    final text = parser.document.encodeHtml ? escapeHtml(url) : url;
     final anchor = Element.text('a', text);
     anchor.attributes['href'] = Uri.encodeFull(url);
     parser.addNode(anchor);

--- a/lib/src/inline_syntaxes/code_syntax.dart
+++ b/lib/src/inline_syntaxes/code_syntax.dart
@@ -47,7 +47,7 @@ class CodeSyntax extends InlineSyntax {
   @override
   bool onMatch(InlineParser parser, Match match) {
     var code = match[2]!.trim().replaceAll('\n', ' ');
-    if (parser.encodeHtml) code = escapeHtml(code);
+    if (parser.document.encodeHtml) code = escapeHtml(code);
     parser.addNode(Element.text('code', code));
 
     return true;

--- a/lib/src/inline_syntaxes/email_autolink_syntax.dart
+++ b/lib/src/inline_syntaxes/email_autolink_syntax.dart
@@ -21,7 +21,7 @@ class EmailAutolinkSyntax extends InlineSyntax {
   @override
   bool onMatch(InlineParser parser, Match match) {
     final url = match[1]!;
-    final text = parser.encodeHtml ? escapeHtml(url) : url;
+    final text = parser.document.encodeHtml ? escapeHtml(url) : url;
     final anchor = Element.text('a', text);
     anchor.attributes['href'] = Uri.encodeFull('mailto:$url');
     parser.addNode(anchor);

--- a/lib/src/inline_syntaxes/escape_syntax.dart
+++ b/lib/src/inline_syntaxes/escape_syntax.dart
@@ -20,7 +20,7 @@ class EscapeSyntax extends InlineSyntax {
     // their equivalent HTML entity referenced appears to be missing from the
     // CommonMark spec, but is very present in all of the examples.
     // https://talk.commonmark.org/t/entity-ification-of-quotes-and-brackets-missing-from-spec/3207
-    if (parser.encodeHtml) {
+    if (parser.document.encodeHtml) {
       if (char == $double_quote) {
         parser.addNode(Text('&quot;'));
       } else if (char == $lt) {

--- a/lib/src/patterns.dart
+++ b/lib/src/patterns.dart
@@ -12,7 +12,8 @@ final setextPattern = RegExp(r'^[ ]{0,3}(=+|-+)\s*$');
 ///
 /// Starts with 1-6 unescaped `#` characters which must not be followed by a
 /// non-space character. Line may end with any number of `#` characters,.
-final headerPattern = RegExp(r'^ {0,3}(#{1,6})[ \x09\x0b\x0c](.*?)#*$');
+final headerPattern =
+    RegExp(r'^( {0,3})(#{1,6})([ \x09\x0b\x0c]+)(.*?)(\s*)(#*)$');
 
 /// The line starts with `>` with one optional space after.
 final blockquotePattern = RegExp(r'^[ ]{0,3}>[ ]?(.*)$');

--- a/lib/src/patterns.dart
+++ b/lib/src/patterns.dart
@@ -13,7 +13,10 @@ final setextPattern = RegExp(r'^[ ]{0,3}(=+|-+)\s*$');
 /// Starts with 1-6 unescaped `#` characters which must not be followed by a
 /// non-space character. Line may end with any number of `#` characters,.
 final headerPattern =
-    RegExp(r'^( {0,3})(#{1,6})([ \x09\x0b\x0c]+)(.*?)(\s*)(#*)$');
+    RegExp(r'^ {0,3}(?<marker>#{1,6})[ \x09\x0b\x0c](?<text>.*?)#*$');
+
+final headerPatternWithHelper = RegExp(
+    r'^( {0,3})(?<marker>#{1,6})([ \x09\x0b\x0c]+)(?<text>.*?)(\s*)(#*)$');
 
 /// The line starts with `>` with one optional space after.
 final blockquotePattern = RegExp(r'^[ ]{0,3}>[ ]?(.*)$');

--- a/lib/src/reverse_renderer.dart
+++ b/lib/src/reverse_renderer.dart
@@ -3,10 +3,10 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'ast.dart';
-import 'block_parser.dart';
+import 'block_syntaxes/block_syntax.dart';
 import 'document.dart';
 import 'extension_set.dart';
-import 'inline_parser.dart';
+import 'inline_syntaxes/inline_syntax.dart';
 import 'util.dart';
 
 /// Converts the given string to AST and render AST to given string itself

--- a/lib/src/reverse_renderer.dart
+++ b/lib/src/reverse_renderer.dart
@@ -1,0 +1,72 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'ast.dart';
+import 'block_parser.dart';
+import 'document.dart';
+import 'extension_set.dart';
+import 'inline_parser.dart';
+import 'util.dart';
+
+/// Converts the given string to AST and render AST to given string itself
+String markdownToMarkdown(
+  String markdown, {
+  Iterable<BlockSyntax> blockSyntaxes = const [],
+  Iterable<InlineSyntax> inlineSyntaxes = const [],
+  ExtensionSet? extensionSet,
+  Resolver? linkResolver,
+  Resolver? imageLinkResolver,
+  bool inlineOnly = false,
+  bool withDefaultBlockSyntaxes = true,
+  bool withDefaultInlineSyntaxes = true,
+}) {
+  final document = Document(
+    blockSyntaxes: blockSyntaxes,
+    inlineSyntaxes: inlineSyntaxes,
+    extensionSet: extensionSet,
+    linkResolver: linkResolver,
+    imageLinkResolver: imageLinkResolver,
+    encodeHtml: false,
+    withDefaultBlockSyntaxes: withDefaultBlockSyntaxes,
+    withDefaultInlineSyntaxes: withDefaultInlineSyntaxes,
+  );
+
+  if (inlineOnly) return renderToMarkdown(document.parseInline(markdown));
+
+  final lines = splitLines(markdown);
+  return renderToMarkdown(document.parseLines(lines));
+}
+
+/// Renders [nodes] to Markdown string.
+String renderToMarkdown(List<Node> nodes) => ReverseRenderer().render(nodes);
+
+/// Translates a parsed AST to Markdown string.
+class ReverseRenderer implements NodeVisitor {
+  ReverseRenderer() : buffer = StringBuffer();
+
+  final StringBuffer buffer;
+
+  String render(List<Node> nodes) {
+    for (final node in nodes) {
+      node.accept(this);
+    }
+    return buffer.toString();
+  }
+
+  @override
+  void visitText(text) {
+    buffer.write(text.text);
+  }
+
+  @override
+  void visitHelper(helper) {
+    buffer.write(helper.textContent);
+  }
+
+  @override
+  bool visitElementBefore(element) => true;
+
+  @override
+  void visitElementAfter(element) {}
+}

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -91,3 +91,7 @@ extension MatchExtensions on Match {
   /// Returns the whole match String
   String get match => this[0]!;
 }
+
+// Replace windows line endings with unix line endings, and split.
+List<String> splitLines(String text) =>
+    text.replaceAll('\r\n', '\n').split('\n');

--- a/test/markdown_test.dart
+++ b/test/markdown_test.dart
@@ -46,6 +46,13 @@ void main() async {
     inlineSyntaxes: [StrikethroughSyntax()],
   );
 
+  // TODO(Zhiguang): enable it
+  // testFile(
+  //   'common_mark/atx_headings.unit',
+  //   inputAsOutput: true,
+  //   blockSyntaxes: [const HeaderSyntax()],
+  // );
+
   await testDirectory('common_mark');
   await testDirectory('gfm', extensionSet: ExtensionSet.gitHubFlavored);
 

--- a/test/util.dart
+++ b/test/util.dart
@@ -12,7 +12,11 @@ import 'package:test/test.dart';
 import '../tool/expected_output.dart';
 
 /// Runs tests defined in "*.unit" files inside directory [name].
-Future<void> testDirectory(String name, {ExtensionSet? extensionSet}) async {
+Future<void> testDirectory(
+  String name, {
+  ExtensionSet? extensionSet,
+  bool inputAsOutput = false,
+}) async {
   await for (final dataCase in dataCasesUnder(testDirectory: name)) {
     final description =
         '${dataCase.directory}/${dataCase.file}.unit ${dataCase.description}';
@@ -65,18 +69,35 @@ void validateCore(
   bool inputAsOutput = false,
 }) {
   test(description, () {
-    final result = markdownToHtml(
-      markdown,
-      blockSyntaxes: blockSyntaxes,
-      inlineSyntaxes: inlineSyntaxes,
-      extensionSet: extensionSet,
-      linkResolver: linkResolver,
-      imageLinkResolver: imageLinkResolver,
-      inlineOnly: inlineOnly,
-    );
+    String result;
+    String expected;
+    if (!inputAsOutput) {
+      expected = html;
+      result = markdownToHtml(markdown,
+          blockSyntaxes: blockSyntaxes,
+          inlineSyntaxes: inlineSyntaxes,
+          extensionSet: extensionSet,
+          linkResolver: linkResolver,
+          imageLinkResolver: imageLinkResolver,
+          inlineOnly: inlineOnly);
+    } else {
+      expected = markdown;
+      result = markdownToMarkdown(markdown,
+          blockSyntaxes: blockSyntaxes,
+          inlineSyntaxes: inlineSyntaxes,
+          extensionSet: extensionSet,
+          linkResolver: linkResolver,
+          imageLinkResolver: imageLinkResolver,
+          // TODO(Zhiguang) Enable default syntaxes when all syntaxes are ready
+          withDefaultBlockSyntaxes: false,
+          withDefaultInlineSyntaxes: false,
+          inlineOnly: inlineOnly);
+    }
 
+    markdownPrintOnFailure(markdown, html, result);
     markdownPrintOnFailure(markdown, expected, result);
 
+    expect(result, html);
     expect(result, expected);
   });
 }

--- a/test/util.dart
+++ b/test/util.dart
@@ -6,6 +6,7 @@ import 'dart:isolate';
 
 import 'package:io/ansi.dart' as ansi;
 import 'package:markdown/markdown.dart';
+import 'package:markdown/src/reverse_renderer.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 import '../tool/expected_output.dart';
@@ -20,6 +21,7 @@ Future<void> testDirectory(String name, {ExtensionSet? extensionSet}) async {
       dataCase.input,
       dataCase.expectedOutput,
       extensionSet: extensionSet,
+      inputAsOutput: inputAsOutput,
     );
   }
 }
@@ -34,6 +36,7 @@ void testFile(
   String file, {
   Iterable<BlockSyntax> blockSyntaxes = const [],
   Iterable<InlineSyntax> inlineSyntaxes = const [],
+  bool inputAsOutput = false,
 }) async {
   final directory = p.join(await markdownPackageRoot, 'test');
   for (final dataCase in dataCasesInFile(path: p.join(directory, file))) {
@@ -59,6 +62,7 @@ void validateCore(
   Resolver? linkResolver,
   Resolver? imageLinkResolver,
   bool inlineOnly = false,
+  bool inputAsOutput = false,
 }) {
   test(description, () {
     final result = markdownToHtml(
@@ -71,9 +75,9 @@ void validateCore(
       inlineOnly: inlineOnly,
     );
 
-    markdownPrintOnFailure(markdown, html, result);
+    markdownPrintOnFailure(markdown, expected, result);
 
-    expect(result, html);
+    expect(result, expected);
   });
 }
 

--- a/test/util.dart
+++ b/test/util.dart
@@ -94,10 +94,7 @@ void validateCore(
           inlineOnly: inlineOnly);
     }
 
-    markdownPrintOnFailure(markdown, html, result);
     markdownPrintOnFailure(markdown, expected, result);
-
-    expect(result, html);
     expect(result, expected);
   });
 }


### PR DESCRIPTION
*No need to merge this PR*

A new AST node type `Helper`(there might be a better name) is introduced, which is used to save the information other than the textContent of Text node and Element node, including markers, whitespaces, blank lines, and line feeds etc. It means the parser will not filter out nor alter any information from the input,  every character will be parsed and kept on AST.

For example:

```
  #   Foo  
```

will be parsed to a AST like this:

![Screenshot 2022-04-12 at 16 19 57](https://user-images.githubusercontent.com/5637609/163003393-408943ef-236e-4d03-a7fb-8849d954c9e3.png)


With this enhancement, this package will work for more scenarios, for example somewhere wants to keep all the string input and highlight the markers, such as markdown editors or comment extensions etc.
