### PR TITLE
Enable prefer_interpolation_to_compose_strings

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -32,3 +32,4 @@ linter:
     - test_types_in_equals
     - throw_in_finally
     - prefer_final_locals
+    - prefer_interpolation_to_compose_strings

--- a/lib/src/block_parser.dart
+++ b/lib/src/block_parser.dart
@@ -782,7 +782,7 @@ abstract class ListSyntax extends BlockSyntax {
           //
           // If the list item starts with a blank line, the final piece of the
           // indentation is just a single space.
-          indent = precedingWhitespace + markerAsSpaces + ' ';
+          indent = '$precedingWhitespace$markerAsSpaces ';
         } else if (restWhitespace.length >= 4) {
           // See http://spec.commonmark.org/0.28/#list-items under "2. Item
           // starting with indented code."
@@ -1181,7 +1181,7 @@ class ParagraphSyntax extends BlockSyntax {
             break;
           }
         } else {
-          contents = contents + '\n' + lines[j];
+          contents = '$contents\n${lines[j]}';
           j++;
         }
       }

--- a/lib/src/html_renderer.dart
+++ b/lib/src/html_renderer.dart
@@ -39,7 +39,9 @@ String markdownToHtml(
   // Replace windows line endings with unix line endings, and split.
   final lines = markdown.replaceAll('\r\n', '\n').split('\n');
 
-  return renderToHtml(document.parseLines(lines)) + '\n';
+  final nodes = document.parseLines(lines);
+
+  return '${renderToHtml(nodes)}\n';
 }
 
 /// Renders [nodes] to HTML.

--- a/tool/expected_output.dart
+++ b/tool/expected_output.dart
@@ -35,12 +35,12 @@ Iterable<DataCase> dataCasesInFile(
 
     var input = '';
     while (!lines[i].startsWith('<<<')) {
-      input += lines[i++] + '\n';
+      input += '${lines[i++]}\n';
     }
 
     var expectedOutput = '';
     while (++i < lines.length && !lines[i].startsWith('>>>')) {
-      expectedOutput += lines[i] + '\n';
+      expectedOutput += '${lines[i]}\n';
     }
 
     final dataCase = DataCase(


### PR DESCRIPTION
see https://dart.dev/guides/language/effective-dart/usage#prefer-using-interpolation-to-compose-strings-and-values

> ...
>  it’s almost always cleaner and shorter to use interpolation

Also it is a good idea to follow a consistent rule.