### PR TITLE
Enable use_if_null_to_convert_nulls_to_bools lint rule

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -32,3 +32,4 @@ linter:
     - test_types_in_equals
     - throw_in_finally
     - prefer_final_locals
+    - use_if_null_to_convert_nulls_to_bools


### PR DESCRIPTION
See https://dart.dev/guides/language/effective-dart/usage#prefer-using--to-convert-null-to-a-boolean-value

It is already a rule we must follow.