### PR TITLE
Enable require_trailing_commas lint rule

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -36,3 +36,4 @@ linter:
     - use_raw_strings
     - unnecessary_raw_strings
     - prefer_interpolation_to_compose_strings
+    - require_trailing_commas

--- a/benchmark/benchmark.dart
+++ b/benchmark/benchmark.dart
@@ -56,8 +56,10 @@ String _loadFile(String name) {
 }
 
 void _printResult(String label, double time) {
-  print('$label: ${_padLeft(time.toStringAsFixed(2), 4)}ms '
-      "${'=' * ((time * 20).toInt())}");
+  print(
+    '$label: ${_padLeft(time.toStringAsFixed(2), 4)}ms '
+    "${'=' * ((time * 20).toInt())}",
+  );
 }
 
 String _padLeft(String input, int length) {

--- a/bin/markdown.dart
+++ b/bin/markdown.dart
@@ -19,16 +19,18 @@ Future<void> main(List<String> args) async {
   final parser = ArgParser()
     ..addFlag('help', negatable: false, help: 'Print help text and exit')
     ..addFlag('version', negatable: false, help: 'Print version and exit')
-    ..addOption('extension-set',
-        allowed: ['none', 'CommonMark', 'GitHubFlavored', 'GitHubWeb'],
-        defaultsTo: 'CommonMark',
-        help: 'Specify a set of extensions',
-        allowedHelp: {
-          'none': 'No extensions; similar to Markdown.pl',
-          'CommonMark': 'Parse like CommonMark Markdown (default)',
-          'GitHubFlavored': 'Parse like GitHub Flavored Markdown',
-          'GitHubWeb': 'Parse like GitHub\'s Markdown-enabled web input fields',
-        });
+    ..addOption(
+      'extension-set',
+      allowed: ['none', 'CommonMark', 'GitHubFlavored', 'GitHubWeb'],
+      defaultsTo: 'CommonMark',
+      help: 'Specify a set of extensions',
+      allowedHelp: {
+        'none': 'No extensions; similar to Markdown.pl',
+        'CommonMark': 'Parse like CommonMark Markdown (default)',
+        'GitHubFlavored': 'Parse like GitHub Flavored Markdown',
+        'GitHubWeb': 'Parse like GitHub\'s Markdown-enabled web input fields',
+      },
+    );
   final results = parser.parse(args);
 
   if (results['help'] as bool) {
@@ -66,7 +68,8 @@ Future<void> main(List<String> args) async {
 }
 
 void printUsage(ArgParser parser) {
-  print('''Usage: markdown.dart [options] [file]
+  print(
+    '''Usage: markdown.dart [options] [file]
 
 Parse [file] as Markdown and print resulting HTML. If [file] is omitted,
 use stdin as input.
@@ -75,5 +78,6 @@ By default, CommonMark Markdown will be parsed. This can be changed with
 the --extensionSet flag.
 
 ${parser.usage}
-''');
+''',
+  );
 }

--- a/example/app.dart
+++ b/example/app.dart
@@ -62,8 +62,10 @@ void main() {
 void _renderMarkdown([Event? event]) {
   final markdown = markdownInput.value!;
 
-  htmlDiv.setInnerHtml(md.markdownToHtml(markdown, extensionSet: extensionSet),
-      treeSanitizer: nullSanitizer);
+  htmlDiv.setInnerHtml(
+    md.markdownToHtml(markdown, extensionSet: extensionSet),
+    treeSanitizer: nullSanitizer,
+  );
 
   for (final block in htmlDiv.querySelectorAll('pre code')) {
     try {

--- a/lib/src/block_parser.dart
+++ b/lib/src/block_parser.dart
@@ -53,7 +53,8 @@ final _olPattern =
 
 /// A line of hyphens separated by at least one pipe.
 final _tablePattern = RegExp(
-    r'^[ ]{0,3}\|?([ \t]*:?\-+:?[ \t]*\|)+([ \t]|[ \t]*:?\-+:?[ \t]*)?$');
+  r'^[ ]{0,3}\|?([ \t]*:?\-+:?[ \t]*\|)+([ \t]|[ \t]*:?\-+:?[ \t]*)?$',
+);
 
 /// A pattern which should never be used. It just satisfies non-nullability of
 /// pattern fields.
@@ -591,13 +592,14 @@ abstract class BlockHtmlSyntax extends BlockSyntax {
 
 class BlockTagBlockHtmlSyntax extends BlockHtmlSyntax {
   static final _pattern = RegExp(
-      '^ {0,3}</?(?:address|article|aside|base|basefont|blockquote|body|'
-      'caption|center|col|colgroup|dd|details|dialog|dir|div|dl|dt|fieldset|'
-      'figcaption|figure|footer|form|frame|frameset|h1|head|header|hr|html|'
-      'iframe|legend|li|link|main|menu|menuitem|meta|nav|noframes|ol|optgroup|'
-      'option|p|param|section|source|summary|table|tbody|td|tfoot|th|thead|'
-      'title|tr|track|ul)'
-      r'(?:\s|>|/>|$)');
+    '^ {0,3}</?(?:address|article|aside|base|basefont|blockquote|body|'
+    'caption|center|col|colgroup|dd|details|dialog|dir|div|dl|dt|fieldset|'
+    'figcaption|figure|footer|form|frame|frameset|h1|head|header|hr|html|'
+    'iframe|legend|li|link|main|menu|menuitem|meta|nav|noframes|ol|optgroup|'
+    'option|p|param|section|source|summary|table|tbody|td|tfoot|th|thead|'
+    'title|tr|track|ul)'
+    r'(?:\s|>|/>|$)',
+  );
 
   /// The [_pattern] regular expression above is very expensive, even on
   /// paragraphs of Markdown with no HTML. This regular expression can be used
@@ -1007,7 +1009,10 @@ class TableSyntax extends BlockSyntax {
   /// [alignments] is used to annotate an alignment on each cell, and
   /// [cellType] is used to declare either "td" or "th" cells.
   Element _parseRow(
-      BlockParser parser, List<String?> alignments, String cellType) {
+    BlockParser parser,
+    List<String?> alignments,
+    String cellType,
+  ) {
     final line = parser.current;
     final cells = <String>[];
     var index = _walkPastOpeningPipe(line);
@@ -1152,7 +1157,9 @@ class ParagraphSyntax extends BlockSyntax {
   /// Extract reference link definitions from the front of the paragraph, and
   /// return the remaining paragraph lines.
   List<String>? _extractReflinkDefinitions(
-      BlockParser parser, List<String> lines) {
+    BlockParser parser,
+    List<String> lines,
+  ) {
     bool lineStartsReflinkDefinition(int i) =>
         lines[i].startsWith(_reflinkDefinitionStart);
 
@@ -1237,13 +1244,14 @@ class ParagraphSyntax extends BlockSyntax {
   // Returns whether [contents] could be parsed as a reference link definition.
   bool _parseReflinkDefinition(BlockParser parser, String contents) {
     final pattern = RegExp(
-        // Leading indentation.
-        '''^[ ]{0,3}'''
-        // Reference id in brackets, and URL.
-        r'''\[((?:\\\]|[^\]])+)\]:\s*(?:<(\S+)>|(\S+))\s*'''
-        // Title in double or single quotes, or parens.
-        r'''("[^"]+"|'[^']+'|\([^)]+\)|)\s*$''',
-        multiLine: true);
+      // Leading indentation.
+      '''^[ ]{0,3}'''
+      // Reference id in brackets, and URL.
+      r'''\[((?:\\\]|[^\]])+)\]:\s*(?:<(\S+)>|(\S+))\s*'''
+      // Title in double or single quotes, or parens.
+      r'''("[^"]+"|'[^']+'|\([^)]+\)|)\s*$''',
+      multiLine: true,
+    );
     final match = pattern.firstMatch(contents);
     if (match == null) {
       // Not a reference link definition.

--- a/lib/src/inline_parser.dart
+++ b/lib/src/inline_parser.dart
@@ -147,14 +147,19 @@ class InlineParser {
     final syntax = delimiter.syntax;
     if (syntax is LinkSyntax && syntaxes.any(((e) => e is LinkSyntax))) {
       final nodeIndex = _tree.lastIndexWhere((n) => n == delimiter.node);
-      final linkNode = syntax.close(this, delimiter, null, getChildren: () {
-        _processDelimiterRun(index);
-        // All of the nodes which lie past [index] are children of this
-        // link/image.
-        final children = _tree.sublist(nodeIndex + 1, _tree.length);
-        _tree.removeRange(nodeIndex + 1, _tree.length);
-        return children;
-      });
+      final linkNode = syntax.close(
+        this,
+        delimiter,
+        null,
+        getChildren: () {
+          _processDelimiterRun(index);
+          // All of the nodes which lie past [index] are children of this
+          // link/image.
+          final children = _tree.sublist(nodeIndex + 1, _tree.length);
+          _tree.removeRange(nodeIndex + 1, _tree.length);
+          return children;
+        },
+      );
       if (linkNode != null) {
         _delimiterStack.removeAt(index);
         if (delimiter.char == $lbracket) {
@@ -171,8 +176,10 @@ class InlineParser {
         advanceBy(1);
       }
     } else {
-      throw StateError('Non-link syntax delimiter found with character '
-          '"${delimiter.char}"');
+      throw StateError(
+        'Non-link syntax delimiter found with character '
+        '"${delimiter.char}"',
+      );
     }
   }
 
@@ -209,9 +216,10 @@ class InlineParser {
       final openersBottomPerCloserLength = openersBottom[closer.char]!;
       final openerBottom = openersBottomPerCloserLength[closer.length % 3];
       final openerIndex = _delimiterStack.lastIndexWhere(
-          (d) =>
-              d.char == closer.char && d.canOpen && _canFormEmphasis(d, closer),
-          currentIndex - 1);
+        (d) =>
+            d.char == closer.char && d.canOpen && _canFormEmphasis(d, closer),
+        currentIndex - 1,
+      );
       if (openerIndex > bottomIndex && openerIndex > openerBottom) {
         // Found an opener for [closer].
         final opener = _delimiterStack[openerIndex];
@@ -219,9 +227,11 @@ class InlineParser {
           currentIndex++;
           continue;
         }
-        final matchedTagIndex = opener.tags.lastIndexWhere((e) =>
-            opener.length >= e.indicatorLength &&
-            closer.length >= e.indicatorLength);
+        final matchedTagIndex = opener.tags.lastIndexWhere(
+          (e) =>
+              opener.length >= e.indicatorLength &&
+              closer.length >= e.indicatorLength,
+        );
         if (matchedTagIndex == -1) {
           currentIndex++;
           continue;
@@ -232,14 +242,23 @@ class InlineParser {
         final openerTextNodeIndex = _tree.indexOf(openerTextNode);
         final closerTextNode = closer.node;
         var closerTextNodeIndex = _tree.indexOf(closerTextNode);
-        final node = opener.syntax.close(this, opener, closer,
-            tag: matchedTag.tag,
-            getChildren: () =>
-                _tree.sublist(openerTextNodeIndex + 1, closerTextNodeIndex));
+        final node = opener.syntax.close(
+          this,
+          opener,
+          closer,
+          tag: matchedTag.tag,
+          getChildren: () => _tree.sublist(
+            openerTextNodeIndex + 1,
+            closerTextNodeIndex,
+          ),
+        );
         // Replace all of the nodes between the opener and the closer (which
         // are now the new emphasis node's children) with the emphasis node.
         _tree.replaceRange(
-            openerTextNodeIndex + 1, closerTextNodeIndex, [node!]);
+          openerTextNodeIndex + 1,
+          closerTextNodeIndex,
+          [node!],
+        );
         // Slide [closerTextNodeIndex] back accordingly.
         closerTextNodeIndex = openerTextNodeIndex + 2;
 
@@ -483,8 +502,10 @@ class EscapeSyntax extends InlineSyntax {
 /// Markdown benchmarking is more mature.
 class InlineHtmlSyntax extends TextSyntax {
   InlineHtmlSyntax()
-      : super(r'<[/!?]?[A-Za-z][A-Za-z0-9-]*(?:\s[^>]*)?>',
-            startCharacter: $lt);
+      : super(
+          r'<[/!?]?[A-Za-z][A-Za-z0-9-]*(?:\s[^>]*)?>',
+          startCharacter: $lt,
+        );
 }
 
 /// Matches autolinks like `<foo@bar.example.com>`.
@@ -716,15 +737,15 @@ class SimpleDelimiter implements Delimiter {
 
   final int endPos;
 
-  SimpleDelimiter(
-      {required this.node,
-      required this.char,
-      required this.length,
-      required this.canOpen,
-      required this.canClose,
-      required this.syntax,
-      required this.endPos})
-      : isActive = true;
+  SimpleDelimiter({
+    required this.node,
+    required this.char,
+    required this.length,
+    required this.canOpen,
+    required this.canClose,
+    required this.syntax,
+    required this.endPos,
+  }) : isActive = true;
 }
 
 /// An implementation of [Delimiter] which uses concepts of "left-flanking" and
@@ -742,28 +763,30 @@ class DelimiterRun implements Delimiter {
   // This RegExp is inspired by
   // https://github.com/commonmark/commonmark.js/blob/1f7d09099c20d7861a674674a5a88733f55ff729/lib/inlines.js#L39.
   // I don't know if there is any way to simplify it or maintain it.
-  static final RegExp punctuation = RegExp('['
-      r'''!"#$%&'()*+,\-./:;<=>?@\[\]\\^_`{|}~'''
-      r'\xA1\xA7\xAB\xB6\xB7\xBB\xBF\u037E\u0387\u055A-\u055F\u0589\u058A\u05BE'
-      r'\u05C0\u05C3\u05C6\u05F3\u05F4\u0609\u060A\u060C\u060D\u061B\u061E'
-      r'\u061F\u066A-\u066D\u06D4\u0700-\u070D\u07F7-\u07F9\u0830-\u083E\u085E'
-      r'\u0964\u0965\u0970\u0AF0\u0DF4\u0E4F\u0E5A\u0E5B\u0F04-\u0F12\u0F14'
-      r'\u0F3A-\u0F3D\u0F85\u0FD0-\u0FD4\u0FD9\u0FDA\u104A-\u104F\u10FB'
-      r'\u1360-\u1368\u1400\u166D\u166E\u169B\u169C\u16EB-\u16ED\u1735\u1736'
-      r'\u17D4-\u17D6\u17D8-\u17DA\u1800-\u180A\u1944\u1945\u1A1E\u1A1F'
-      r'\u1AA0-\u1AA6\u1AA8-\u1AAD\u1B5A-\u1B60\u1BFC-\u1BFF\u1C3B-\u1C3F\u1C7E'
-      r'\u1C7F\u1CC0-\u1CC7\u1CD3\u2010-\u2027\u2030-\u2043\u2045-\u2051'
-      r'\u2053-\u205E\u207D\u207E\u208D\u208E\u2308-\u230B\u2329\u232A'
-      r'\u2768-\u2775\u27C5\u27C6\u27E6-\u27EF\u2983-\u2998\u29D8-\u29DB\u29FC'
-      r'\u29FD\u2CF9-\u2CFC\u2CFE\u2CFF\u2D70\u2E00-\u2E2E\u2E30-\u2E42'
-      r'\u3001-\u3003\u3008-\u3011\u3014-\u301F\u3030\u303D\u30A0\u30FB\uA4FE'
-      r'\uA4FF\uA60D-\uA60F\uA673\uA67E\uA6F2-\uA6F7\uA874-\uA877\uA8CE\uA8CF'
-      r'\uA8F8-\uA8FA\uA8FC\uA92E\uA92F\uA95F\uA9C1-\uA9CD\uA9DE\uA9DF'
-      r'\uAA5C-\uAA5F\uAADE\uAADF\uAAF0\uAAF1\uABEB\uFD3E\uFD3F\uFE10-\uFE19'
-      r'\uFE30-\uFE52\uFE54-\uFE61\uFE63\uFE68\uFE6A\uFE6B\uFF01-\uFF03'
-      r'\uFF05-\uFF0A\uFF0C-\uFF0F\uFF1A\uFF1B\uFF1F\uFF20\uFF3B-\uFF3D\uFF3F'
-      r'\uFF5B\uFF5D\uFF5F-\uFF65'
-      ']');
+  static final RegExp punctuation = RegExp(
+    '['
+    r'''!"#$%&'()*+,\-./:;<=>?@\[\]\\^_`{|}~'''
+    r'\xA1\xA7\xAB\xB6\xB7\xBB\xBF\u037E\u0387\u055A-\u055F\u0589\u058A\u05BE'
+    r'\u05C0\u05C3\u05C6\u05F3\u05F4\u0609\u060A\u060C\u060D\u061B\u061E'
+    r'\u061F\u066A-\u066D\u06D4\u0700-\u070D\u07F7-\u07F9\u0830-\u083E\u085E'
+    r'\u0964\u0965\u0970\u0AF0\u0DF4\u0E4F\u0E5A\u0E5B\u0F04-\u0F12\u0F14'
+    r'\u0F3A-\u0F3D\u0F85\u0FD0-\u0FD4\u0FD9\u0FDA\u104A-\u104F\u10FB'
+    r'\u1360-\u1368\u1400\u166D\u166E\u169B\u169C\u16EB-\u16ED\u1735\u1736'
+    r'\u17D4-\u17D6\u17D8-\u17DA\u1800-\u180A\u1944\u1945\u1A1E\u1A1F'
+    r'\u1AA0-\u1AA6\u1AA8-\u1AAD\u1B5A-\u1B60\u1BFC-\u1BFF\u1C3B-\u1C3F\u1C7E'
+    r'\u1C7F\u1CC0-\u1CC7\u1CD3\u2010-\u2027\u2030-\u2043\u2045-\u2051'
+    r'\u2053-\u205E\u207D\u207E\u208D\u208E\u2308-\u230B\u2329\u232A'
+    r'\u2768-\u2775\u27C5\u27C6\u27E6-\u27EF\u2983-\u2998\u29D8-\u29DB\u29FC'
+    r'\u29FD\u2CF9-\u2CFC\u2CFE\u2CFF\u2D70\u2E00-\u2E2E\u2E30-\u2E42'
+    r'\u3001-\u3003\u3008-\u3011\u3014-\u301F\u3030\u303D\u30A0\u30FB\uA4FE'
+    r'\uA4FF\uA60D-\uA60F\uA673\uA67E\uA6F2-\uA6F7\uA874-\uA877\uA8CE\uA8CF'
+    r'\uA8F8-\uA8FA\uA8FC\uA92E\uA92F\uA95F\uA9C1-\uA9CD\uA9DE\uA9DF'
+    r'\uAA5C-\uAA5F\uAADE\uAADF\uAAF0\uAAF1\uABEB\uFD3E\uFD3F\uFE10-\uFE19'
+    r'\uFE30-\uFE52\uFE54-\uFE61\uFE63\uFE68\uFE6A\uFE6B\uFF01-\uFF03'
+    r'\uFF05-\uFF0A\uFF0C-\uFF0F\uFF1A\uFF1B\uFF1F\uFF20\uFF3B-\uFF3D\uFF3F'
+    r'\uFF5B\uFF5D\uFF5F-\uFF65'
+    ']',
+  );
 
   // TODO(srawlins): Unicode whitespace
   static final String whitespace = ' \t\r\n';
@@ -811,11 +834,15 @@ class DelimiterRun implements Delimiter {
 
   /// Tries to parse a delimiter run from [runStart] (inclusive) to [runEnd]
   /// (exclusive).
-  static DelimiterRun? tryParse(InlineParser parser, int runStart, int runEnd,
-      {required DelimiterSyntax syntax,
-      required List<DelimiterTag> tags,
-      required Text node,
-      bool allowIntraWord = false}) {
+  static DelimiterRun? tryParse(
+    InlineParser parser,
+    int runStart,
+    int runEnd, {
+    required DelimiterSyntax syntax,
+    required List<DelimiterTag> tags,
+    required Text node,
+    bool allowIntraWord = false,
+  }) {
     bool leftFlanking,
         rightFlanking,
         precededByPunctuation,
@@ -911,12 +938,13 @@ class DelimiterSyntax extends InlineSyntax {
   /// is passed, this syntax parses according to the same nesting rules as
   /// emphasis delimiters.  If [startCharacter] is passed, it is used as a
   /// pre-matching check which is faster than matching against [pattern].
-  DelimiterSyntax(String pattern,
-      {this.requiresDelimiterRun = false,
-      int? startCharacter,
-      this.allowIntraWord = false,
-      this.tags})
-      : super(pattern, startCharacter: startCharacter);
+  DelimiterSyntax(
+    String pattern, {
+    this.requiresDelimiterRun = false,
+    int? startCharacter,
+    this.allowIntraWord = false,
+    this.tags,
+  }) : super(pattern, startCharacter: startCharacter);
 
   @override
   bool onMatch(InlineParser parser, Match match) {
@@ -925,23 +953,30 @@ class DelimiterSyntax extends InlineSyntax {
     final matchEnd = parser.pos + runLength;
     final text = Text(parser.source.substring(matchStart, matchEnd));
     if (!requiresDelimiterRun) {
-      parser._pushDelimiter(SimpleDelimiter(
+      parser._pushDelimiter(
+        SimpleDelimiter(
           node: text,
           length: runLength,
           char: parser.source.codeUnitAt(matchStart),
           canOpen: true,
           canClose: false,
           syntax: this,
-          endPos: matchEnd));
+          endPos: matchEnd,
+        ),
+      );
       parser.addNode(text);
       return true;
     }
 
-    final delimiterRun = DelimiterRun.tryParse(parser, matchStart, matchEnd,
-        syntax: this,
-        node: text,
-        allowIntraWord: allowIntraWord,
-        tags: tags ?? []);
+    final delimiterRun = DelimiterRun.tryParse(
+      parser,
+      matchStart,
+      matchEnd,
+      syntax: this,
+      node: text,
+      allowIntraWord: allowIntraWord,
+      tags: tags ?? [],
+    );
     if (delimiterRun != null) {
       parser._pushDelimiter(delimiterRun);
       parser.addNode(text);
@@ -979,8 +1014,12 @@ class EmphasisSyntax extends DelimiterSyntax {
 
   /// Parses `**strong**` and `*emphasis*`.
   EmphasisSyntax.asterisk()
-      : super(r'\*+',
-            requiresDelimiterRun: true, allowIntraWord: true, tags: _tags);
+      : super(
+          r'\*+',
+          requiresDelimiterRun: true,
+          allowIntraWord: true,
+          tags: _tags,
+        );
 
   static final _tags = [DelimiterTag('em', 1), DelimiterTag('strong', 2)];
 }
@@ -988,10 +1027,12 @@ class EmphasisSyntax extends DelimiterSyntax {
 /// Matches strikethrough syntax according to the GFM spec.
 class StrikethroughSyntax extends DelimiterSyntax {
   StrikethroughSyntax()
-      : super('~+',
-            requiresDelimiterRun: true,
-            allowIntraWord: true,
-            tags: [DelimiterTag('del', 2)]);
+      : super(
+          '~+',
+          requiresDelimiterRun: true,
+          allowIntraWord: true,
+          tags: [DelimiterTag('del', 2)],
+        );
 }
 
 @Deprecated('Use DelimiterSyntax instead')
@@ -1006,11 +1047,11 @@ class LinkSyntax extends DelimiterSyntax {
 
   final Resolver linkResolver;
 
-  LinkSyntax(
-      {Resolver? linkResolver,
-      String pattern = r'\[',
-      int startCharacter = $lbracket})
-      : linkResolver = (linkResolver ?? ((String _, [String? __]) => null)),
+  LinkSyntax({
+    Resolver? linkResolver,
+    String pattern = r'\[',
+    int startCharacter = $lbracket,
+  })  : linkResolver = (linkResolver ?? ((String _, [String? __]) => null)),
         super(pattern, startCharacter: startCharacter);
 
   @override
@@ -1041,8 +1082,11 @@ class LinkSyntax extends DelimiterSyntax {
       final leftParenIndex = parser.pos;
       final inlineLink = _parseInlineLink(parser);
       if (inlineLink != null) {
-        return _tryCreateInlineLink(parser, inlineLink,
-            getChildren: getChildren);
+        return _tryCreateInlineLink(
+          parser,
+          inlineLink,
+          getChildren: getChildren,
+        );
       }
       // At this point, we've matched `[...](`, but that `(` did not pan out to
       // be an inline link. We must now check if `[...]` is simply a shortcut
@@ -1088,12 +1132,17 @@ class LinkSyntax extends DelimiterSyntax {
   ///
   /// [label] does not need to be normalized.
   Node? _resolveReferenceLink(
-      String label, Map<String, LinkReference> linkReferences,
-      {required List<Node> Function() getChildren}) {
+    String label,
+    Map<String, LinkReference> linkReferences, {
+    required List<Node> Function() getChildren,
+  }) {
     final linkReference = linkReferences[normalizeLinkLabel(label)];
     if (linkReference != null) {
-      return _createNode(linkReference.destination, linkReference.title,
-          getChildren: getChildren);
+      return _createNode(
+        linkReference.destination,
+        linkReference.title,
+        getChildren: getChildren,
+      );
     } else {
       // This link has no reference definition. But we allow users of the
       // library to specify a custom resolver function ([linkResolver]) that
@@ -1103,10 +1152,12 @@ class LinkSyntax extends DelimiterSyntax {
       // Normally, label text does not get parsed as inline Markdown. However,
       // for the benefit of the link resolver, we need to at least escape
       // brackets, so that, e.g. a link resolver can receive `[\[\]]` as `[]`.
-      final resolved = linkResolver(label
-          .replaceAll(r'\\', r'\')
-          .replaceAll(r'\[', '[')
-          .replaceAll(r'\]', ']'));
+      final resolved = linkResolver(
+        label
+            .replaceAll(r'\\', r'\')
+            .replaceAll(r'\[', '[')
+            .replaceAll(r'\]', ']'),
+      );
       if (resolved != null) {
         getChildren();
       }
@@ -1115,8 +1166,11 @@ class LinkSyntax extends DelimiterSyntax {
   }
 
   /// Create the node represented by a Markdown link.
-  Node _createNode(String destination, String? title,
-      {required List<Node> Function() getChildren}) {
+  Node _createNode(
+    String destination,
+    String? title, {
+    required List<Node> Function() getChildren,
+  }) {
     final children = getChildren();
     final element = Element('a', children);
     element.attributes['href'] = escapeAttribute(destination);
@@ -1129,17 +1183,26 @@ class LinkSyntax extends DelimiterSyntax {
   /// Tries to create a reference link node.
   ///
   /// Returns the link if it was successfully created, `null` otherwise.
-  Node? _tryCreateReferenceLink(InlineParser parser, String label,
-      {required List<Node> Function() getChildren}) {
-    return _resolveReferenceLink(label, parser.document.linkReferences,
-        getChildren: getChildren);
+  Node? _tryCreateReferenceLink(
+    InlineParser parser,
+    String label, {
+    required List<Node> Function() getChildren,
+  }) {
+    return _resolveReferenceLink(
+      label,
+      parser.document.linkReferences,
+      getChildren: getChildren,
+    );
   }
 
   // Tries to create an inline link node.
   //
   /// Returns the link if it was successfully created, `null` otherwise.
-  Node _tryCreateInlineLink(InlineParser parser, InlineLink link,
-      {required List<Node> Function() getChildren}) {
+  Node _tryCreateInlineLink(
+    InlineParser parser,
+    InlineLink link, {
+    required List<Node> Function() getChildren,
+  }) {
     return _createNode(link.destination, link.title, getChildren: getChildren);
   }
 
@@ -1413,13 +1476,17 @@ class LinkSyntax extends DelimiterSyntax {
 class ImageSyntax extends LinkSyntax {
   ImageSyntax({Resolver? linkResolver})
       : super(
-            linkResolver: linkResolver,
-            pattern: r'!\[',
-            startCharacter: $exclamation);
+          linkResolver: linkResolver,
+          pattern: r'!\[',
+          startCharacter: $exclamation,
+        );
 
   @override
-  Element _createNode(String destination, String? title,
-      {required List<Node> Function() getChildren}) {
+  Element _createNode(
+    String destination,
+    String? title, {
+    required List<Node> Function() getChildren,
+  }) {
     final element = Element.empty('img');
     final children = getChildren();
     element.attributes['src'] = destination;

--- a/test/document_test.dart
+++ b/test/document_test.dart
@@ -14,9 +14,9 @@ void main() {
       final result = document.parseInline('< &');
       expect(result, hasLength(1));
       expect(
-          result[0],
-          const TypeMatcher<Text>()
-              .having((e) => e.text, 'text', equals('< &')));
+        result[0],
+        const TypeMatcher<Text>().having((e) => e.text, 'text', equals('< &')),
+      );
     });
 
     group('with encodeHtml enabled', () {
@@ -26,24 +26,30 @@ void main() {
         final result =
             document.parseInline('``<p>Hello <em>Markdown</em></p>``');
         final codeSnippet = result.single as Element;
-        expect(codeSnippet.textContent,
-            equals('&lt;p&gt;Hello &lt;em&gt;Markdown&lt;/em&gt;&lt;/p&gt;'));
+        expect(
+          codeSnippet.textContent,
+          equals('&lt;p&gt;Hello &lt;em&gt;Markdown&lt;/em&gt;&lt;/p&gt;'),
+        );
       });
 
       test('encodes HTML in a fenced code block', () {
         final lines = '```\n<p>Hello <em>Markdown</em></p>\n```\n'.split('\n');
         final result = document.parseLines(lines);
         final codeBlock = result.single as Element;
-        expect(codeBlock.textContent,
-            equals('&lt;p&gt;Hello &lt;em&gt;Markdown&lt;/em&gt;&lt;/p&gt;\n'));
+        expect(
+          codeBlock.textContent,
+          equals('&lt;p&gt;Hello &lt;em&gt;Markdown&lt;/em&gt;&lt;/p&gt;\n'),
+        );
       });
 
       test('encodes HTML in an indented code block', () {
         final lines = '    <p>Hello <em>Markdown</em></p>\n'.split('\n');
         final result = document.parseLines(lines);
         final codeBlock = result.single as Element;
-        expect(codeBlock.textContent,
-            equals('&lt;p&gt;Hello &lt;em&gt;Markdown&lt;/em&gt;&lt;/p&gt;\n'));
+        expect(
+          codeBlock.textContent,
+          equals('&lt;p&gt;Hello &lt;em&gt;Markdown&lt;/em&gt;&lt;/p&gt;\n'),
+        );
       });
 
       test('encodeHtml spaces are preserved in text', () {
@@ -63,12 +69,13 @@ void main() {
         final nodes = document.parseInline(contents);
         expect(nodes, hasLength(1));
         expect(
-            nodes.single,
-            const TypeMatcher<Text>().having(
-              (e) => e.text,
-              'text',
-              '&gt;&quot;&lt; Hello',
-            ));
+          nodes.single,
+          const TypeMatcher<Text>().having(
+            (e) => e.text,
+            'text',
+            '&gt;&quot;&lt; Hello',
+          ),
+        );
       });
     });
 
@@ -80,7 +87,9 @@ void main() {
             document.parseInline('```<p>Hello <em>Markdown</em></p>```');
         final codeSnippet = result.single as Element;
         expect(
-            codeSnippet.textContent, equals('<p>Hello <em>Markdown</em></p>'));
+          codeSnippet.textContent,
+          equals('<p>Hello <em>Markdown</em></p>'),
+        );
       });
 
       test('leaves HTML alone, in a fenced code block', () {
@@ -88,7 +97,9 @@ void main() {
         final result = document.parseLines(lines);
         final codeBlock = result.single as Element;
         expect(
-            codeBlock.textContent, equals('<p>Hello <em>Markdown</em></p>\n'));
+          codeBlock.textContent,
+          equals('<p>Hello <em>Markdown</em></p>\n'),
+        );
       });
 
       test('leaves HTML alone, in an indented code block', () {
@@ -96,7 +107,9 @@ void main() {
         final result = document.parseLines(lines);
         final codeBlock = result.single as Element;
         expect(
-            codeBlock.textContent, equals('<p>Hello <em>Markdown</em></p>\n'));
+          codeBlock.textContent,
+          equals('<p>Hello <em>Markdown</em></p>\n'),
+        );
       });
 
       test('leave double quotes, greater than, and less than when escaped', () {
@@ -105,12 +118,9 @@ void main() {
         final nodes = document.parseInline(contents);
         expect(nodes, hasLength(1));
         expect(
-            nodes.single,
-            const TypeMatcher<Text>().having(
-              (e) => e.text,
-              'text',
-              '>"< Hello',
-            ));
+          nodes.single,
+          const TypeMatcher<Text>().having((e) => e.text, 'text', '>"< Hello'),
+        );
       });
     });
   });

--- a/test/markdown_test.dart
+++ b/test/markdown_test.dart
@@ -11,124 +11,170 @@ void main() async {
   await testDirectory('original');
 
   // Block syntax extensions
-  testFile('extensions/fenced_code_blocks.unit',
-      blockSyntaxes: [const FencedCodeBlockSyntax()]);
-  testFile('extensions/headers_with_ids.unit',
-      blockSyntaxes: [const HeaderWithIdSyntax()]);
-  testFile('extensions/setext_headers_with_ids.unit',
-      blockSyntaxes: [const SetextHeaderWithIdSyntax()]);
-  testFile('extensions/tables.unit', blockSyntaxes: [const TableSyntax()]);
-  testFile('extensions/fenced_blockquotes.unit',
-      blockSyntaxes: [const FencedBlockquoteSyntax()]);
+  testFile(
+    'extensions/fenced_code_blocks.unit',
+    blockSyntaxes: [const FencedCodeBlockSyntax()],
+  );
+  testFile(
+    'extensions/headers_with_ids.unit',
+    blockSyntaxes: [const HeaderWithIdSyntax()],
+  );
+  testFile(
+    'extensions/setext_headers_with_ids.unit',
+    blockSyntaxes: [const SetextHeaderWithIdSyntax()],
+  );
+  testFile(
+    'extensions/tables.unit',
+    blockSyntaxes: [const TableSyntax()],
+  );
+  testFile(
+    'extensions/fenced_blockquotes.unit',
+    blockSyntaxes: [const FencedBlockquoteSyntax()],
+  );
 
   // Inline syntax extensions
-  testFile('extensions/emojis.unit', inlineSyntaxes: [EmojiSyntax()]);
-  testFile('extensions/inline_html.unit', inlineSyntaxes: [InlineHtmlSyntax()]);
-  testFile('extensions/strikethrough.unit',
-      inlineSyntaxes: [StrikethroughSyntax()]);
+  testFile(
+    'extensions/emojis.unit',
+    inlineSyntaxes: [EmojiSyntax()],
+  );
+  testFile(
+    'extensions/inline_html.unit',
+    inlineSyntaxes: [InlineHtmlSyntax()],
+  );
+  testFile(
+    'extensions/strikethrough.unit',
+    inlineSyntaxes: [StrikethroughSyntax()],
+  );
 
   await testDirectory('common_mark');
-  await testDirectory('gfm', extensionSet: ExtensionSet.gitHubFlavored);
+  await testDirectory(
+    'gfm',
+    extensionSet: ExtensionSet.gitHubFlavored,
+  );
 
   group('Corner cases', () {
-    validateCore('Incorrect Links', '''
+    validateCore(
+      'Incorrect Links',
+      '''
 5 Ethernet ([Music](
-''', '''
+''',
+      '''
 <p>5 Ethernet ([Music](</p>
-''');
+''',
+    );
 
-    validateCore('Escaping code block language', '''
+    validateCore(
+      'Escaping code block language',
+      '''
 ```"/><a/href="url">arbitrary_html</a>
 ```
-''', '''
+''',
+      '''
 <pre><code class="language-&quot;/&gt;&lt;a/href=&quot;url&quot;&gt;arbitrary_html&lt;/a&gt;"></code></pre>
-''');
+''',
+    );
 
-    validateCore('Unicode ellipsis as punctuation', '''
+    validateCore(
+      'Unicode ellipsis as punctuation',
+      '''
 "Connecting dot **A** to **B.**…"
-''', '''
+''',
+      '''
 <p>"Connecting dot <strong>A</strong> to <strong>B.</strong>…"</p>
-''');
+''',
+    );
   });
 
   group('Resolver', () {
     Node? nyanResolver(String text, [_]) =>
         text.isEmpty ? null : Text('~=[,,_${text}_,,]:3');
     validateCore(
-        'simple link resolver',
-        '''
+      'simple link resolver',
+      '''
 resolve [this] thing
 ''',
-        '''
+      '''
 <p>resolve ~=[,,_this_,,]:3 thing</p>
 ''',
-        linkResolver: nyanResolver);
+      linkResolver: nyanResolver,
+    );
 
     validateCore(
-        'simple image resolver',
-        '''
+      'simple image resolver',
+      '''
 resolve ![this] thing
 ''',
-        '''
+      '''
 <p>resolve ~=[,,_this_,,]:3 thing</p>
 ''',
-        imageLinkResolver: nyanResolver);
+      imageLinkResolver: nyanResolver,
+    );
 
     validateCore(
-        'can resolve link containing inline tags',
-        '''
+      'can resolve link containing inline tags',
+      '''
 resolve [*star* _underline_] thing
 ''',
-        '''
+      '''
 <p>resolve ~=[,,_*star* _underline__,,]:3 thing</p>
 ''',
-        linkResolver: nyanResolver);
+      linkResolver: nyanResolver,
+    );
 
     validateCore(
-        'link resolver uses un-normalized link label',
-        '''
+      'link resolver uses un-normalized link label',
+      '''
 resolve [TH  IS] thing
 ''',
-        '''
+      '''
 <p>resolve ~=[,,_TH  IS_,,]:3 thing</p>
 ''',
-        linkResolver: nyanResolver);
+      linkResolver: nyanResolver,
+    );
 
     validateCore(
-        'can resolve escaped brackets',
-        r'''
+      'can resolve escaped brackets',
+      r'''
 resolve [\[\]] thing
 ''',
-        '''
+      '''
 <p>resolve ~=[,,_[]_,,]:3 thing</p>
 ''',
-        linkResolver: nyanResolver);
+      linkResolver: nyanResolver,
+    );
 
     validateCore(
-        'can choose to _not_ resolve something, like an empty link',
-        '''
+      'can choose to _not_ resolve something, like an empty link',
+      '''
 resolve [[]] thing
 ''',
-        '''
+      '''
 <p>resolve ~=[,,_[]_,,]:3 thing</p>
 ''',
-        linkResolver: nyanResolver);
+      linkResolver: nyanResolver,
+    );
   });
 
   group('Custom inline syntax', () {
     final nyanSyntax = <InlineSyntax>[TextSyntax('nyan', sub: '~=[,,_,,]:3')];
     validateCore(
-        'simple inline syntax',
-        '''
+      'simple inline syntax',
+      '''
 nyan''',
-        '''<p>~=[,,_,,]:3</p>
+      '''<p>~=[,,_,,]:3</p>
 ''',
-        inlineSyntaxes: nyanSyntax);
+      inlineSyntaxes: nyanSyntax,
+    );
 
-    validateCore('dart custom links', 'links [are<foo>] awesome',
-        '<p>links <a>are&lt;foo></a> awesome</p>\n',
-        linkResolver: (String text, [String? _]) =>
-            Element.text('a', text.replaceAll('<', '&lt;')));
+    validateCore(
+      'dart custom links',
+      'links [are<foo>] awesome',
+      '<p>links <a>are&lt;foo></a> awesome</p>\n',
+      linkResolver: (String text, [String? _]) => Element.text(
+        'a',
+        text.replaceAll('<', '&lt;'),
+      ),
+    );
 
     // TODO(amouravski): need more tests here for custom syntaxes, as some
     // things are not quite working properly. The regexps are sometime a little
@@ -137,69 +183,76 @@ nyan''',
 
   group('Inline only', () {
     validateCore(
-        'simple line',
-        '''
-        This would normally create a paragraph.
-        ''',
-        '''
-        This would normally create a paragraph.
-        ''',
-        inlineOnly: true);
+      'simple line',
+      '''
+      This would normally create a paragraph.
+      ''',
+      '''
+      This would normally create a paragraph.
+      ''',
+      inlineOnly: true,
+    );
     validateCore(
-        'strong and em',
-        '''
-        This would _normally_ create a **paragraph**.
-        ''',
-        '''
-        This would <em>normally</em> create a <strong>paragraph</strong>.
-        ''',
-        inlineOnly: true);
+      'strong and em',
+      '''
+      This would _normally_ create a **paragraph**.
+      ''',
+      '''
+      This would <em>normally</em> create a <strong>paragraph</strong>.
+      ''',
+      inlineOnly: true,
+    );
     validateCore(
-        'link',
-        '''
-        This [link](http://www.example.com/) will work normally.
-        ''',
-        '''
-        This <a href="http://www.example.com/">link</a> will work normally.
-        ''',
-        inlineOnly: true);
+      'link',
+      '''
+      This [link](http://www.example.com/) will work normally.
+      ''',
+      '''
+      This <a href="http://www.example.com/">link</a> will work normally.
+      ''',
+      inlineOnly: true,
+    );
     validateCore(
-        'references do not work',
-        '''
-        [This][] shouldn't work, though.
-        ''',
-        '''
-        [This][] shouldn't work, though.
-        ''',
-        inlineOnly: true);
+      'references do not work',
+      '''
+      [This][] shouldn't work, though.
+      ''',
+      '''
+      [This][] shouldn't work, though.
+      ''',
+      inlineOnly: true,
+    );
     validateCore(
-        'less than and ampersand are escaped',
-        '''
-        < &
-        ''',
-        '''
-        &lt; &amp;
-        ''',
-        inlineOnly: true);
+      'less than and ampersand are escaped',
+      '''
+      < &
+      ''',
+      '''
+      &lt; &amp;
+      ''',
+      inlineOnly: true,
+    );
     validateCore(
-        'keeps newlines',
-        '''
-        This paragraph
-        continues after a newline.
-        ''',
-        '''
-        This paragraph
-        continues after a newline.
-        ''',
-        inlineOnly: true);
+      'keeps newlines',
+      '''
+      This paragraph
+      continues after a newline.
+      ''',
+      '''
+      This paragraph
+      continues after a newline.
+      ''',
+      inlineOnly: true,
+    );
     validateCore(
-        'ignores block-level markdown syntax',
-        '''
-        1. This will not be an <ol>.
-        ''',
-        '''
-        1. This will not be an <ol>.
-        ''',
-        inlineOnly: true);
+      'ignores block-level markdown syntax',
+      '''
+      1. This will not be an <ol>.
+      ''',
+      '''
+      1. This will not be an <ol>.
+      ''',
+      inlineOnly: true,
+    );
   });
 }

--- a/test/util.dart
+++ b/test/util.dart
@@ -24,10 +24,14 @@ Future<void> testDirectory(String name, {ExtensionSet? extensionSet}) async {
   }
 }
 
-Future<String> get markdownPackageRoot async =>
-    p.dirname(p.dirname((await Isolate.resolvePackageUri(
-            Uri.parse('package:markdown/markdown.dart')))!
-        .toFilePath()));
+Future<String> get markdownPackageRoot async => p.dirname(
+      p.dirname(
+        (await Isolate.resolvePackageUri(
+          Uri.parse('package:markdown/markdown.dart'),
+        ))!
+            .toFilePath(),
+      ),
+    );
 
 void testFile(
   String file, {
@@ -38,8 +42,13 @@ void testFile(
   for (final dataCase in dataCasesInFile(path: p.join(directory, file))) {
     final description =
         '${dataCase.directory}/${dataCase.file}.unit ${dataCase.description}';
-    validateCore(description, dataCase.input, dataCase.expectedOutput,
-        blockSyntaxes: blockSyntaxes, inlineSyntaxes: inlineSyntaxes);
+    validateCore(
+      description,
+      dataCase.input,
+      dataCase.expectedOutput,
+      blockSyntaxes: blockSyntaxes,
+      inlineSyntaxes: inlineSyntaxes,
+    );
   }
 }
 
@@ -55,13 +64,15 @@ void validateCore(
   bool inlineOnly = false,
 }) {
   test(description, () {
-    final result = markdownToHtml(markdown,
-        blockSyntaxes: blockSyntaxes,
-        inlineSyntaxes: inlineSyntaxes,
-        extensionSet: extensionSet,
-        linkResolver: linkResolver,
-        imageLinkResolver: imageLinkResolver,
-        inlineOnly: inlineOnly);
+    final result = markdownToHtml(
+      markdown,
+      blockSyntaxes: blockSyntaxes,
+      inlineSyntaxes: inlineSyntaxes,
+      extensionSet: extensionSet,
+      linkResolver: linkResolver,
+      imageLinkResolver: imageLinkResolver,
+      inlineOnly: inlineOnly,
+    );
 
     markdownPrintOnFailure(markdown, html, result);
 
@@ -74,7 +85,8 @@ String whitespaceColor(String input) => input
     .replaceAll('\t', ansi.backgroundDarkGray.wrap('\t')!);
 
 void markdownPrintOnFailure(String markdown, String expected, String actual) {
-  printOnFailure("""
+  printOnFailure(
+    """
 INPUT:
 '''r
 ${whitespaceColor(markdown)}'''            
@@ -86,5 +98,6 @@ ${whitespaceColor(expected)}'''
 GOT:
 '''r
 ${whitespaceColor(actual)}'''
-""");
+""",
+  );
 }

--- a/test/version_test.dart
+++ b/test/version_test.dart
@@ -16,10 +16,13 @@ void main() {
     final binary = p.normalize(p.join(packageRoot, 'bin', 'markdown.dart'));
     final dartBin = Platform.executable;
     final result = Process.runSync(dartBin, [binary, '--version']);
-    expect(result.exitCode, 0,
-        reason: 'Exit code expected: 0; actual: ${result.exitCode}\n\n'
-            'stdout: ${result.stdout}\n\n'
-            'stderr: ${result.stderr}');
+    expect(
+      result.exitCode,
+      0,
+      reason: 'Exit code expected: 0; actual: ${result.exitCode}\n\n'
+          'stdout: ${result.stdout}\n\n'
+          'stderr: ${result.stderr}',
+    );
 
     final binVersion = (result.stdout as String).trim();
 
@@ -28,8 +31,11 @@ void main() {
     final pubspecContent =
         loadYaml(File(pubspecFile).readAsStringSync()) as YamlMap;
 
-    expect(binVersion, pubspecContent['version'],
-        reason: 'The version reported by bin/markdown.dart should match the '
-            'version in pubspec. Run `pub run build_runner build` to update.');
+    expect(
+      binVersion,
+      pubspecContent['version'],
+      reason: 'The version reported by bin/markdown.dart should match the '
+          'version in pubspec. Run `pub run build_runner build` to update.',
+    );
   });
 }

--- a/tool/dartdoc_compare.dart
+++ b/tool/dartdoc_compare.dart
@@ -18,12 +18,25 @@ const _help = 'help';
 void main(List<String> arguments) {
   final parser = ArgParser()
     ..addSeparator('Usage: dartdoc-compare.dart [OPTIONS] <dart-package>')
-    ..addOption(_dartdocDir, help: 'Directory of the dartdoc package')
-    ..addOption(_markdownBefore, help: "Markdown package 'before' ref")
-    ..addOption(_markdownAfter,
-        defaultsTo: 'HEAD', help: "Markdown package 'after' ref (or 'local')")
-    ..addFlag(_sdk,
-        defaultsTo: false, negatable: false, help: 'Is the package the SDK?')
+    ..addOption(
+      _dartdocDir,
+      help: 'Directory of the dartdoc package',
+    )
+    ..addOption(
+      _markdownBefore,
+      help: "Markdown package 'before' ref",
+    )
+    ..addOption(
+      _markdownAfter,
+      defaultsTo: 'HEAD',
+      help: "Markdown package 'after' ref (or 'local')",
+    )
+    ..addFlag(
+      _sdk,
+      defaultsTo: false,
+      negatable: false,
+      help: 'Is the package the SDK?',
+    )
     ..addFlag(_help, abbr: 'h', hide: true);
 
   final options = parser.parse(arguments);
@@ -34,18 +47,20 @@ void main(List<String> arguments) {
   }
   if (options[_dartdocDir] == null || options[_markdownBefore] == null) {
     print(
-        'Invalid arguments: Options --$_dartdocDir and --$_markdownBefore must be specified');
+      'Invalid arguments: Options --$_dartdocDir and --$_markdownBefore must be specified',
+    );
     print(parser.usage);
     exitCode = 1;
     return;
   }
   final comparer = DartdocCompare(
-      options[_dartdocDir] as String,
-      options[_markdownBefore] as String,
-      options[_markdownAfter] as String,
-      absolute(options[_dartdocDir] as String, 'bin/dartdoc.dart'),
-      absolute(options[_dartdocDir] as String, 'pubspec.yaml'),
-      options[_sdk] as bool);
+    options[_dartdocDir] as String,
+    options[_markdownBefore] as String,
+    options[_markdownAfter] as String,
+    absolute(options[_dartdocDir] as String, 'bin/dartdoc.dart'),
+    absolute(options[_dartdocDir] as String, 'pubspec.yaml'),
+    options[_sdk] as bool,
+  );
 
   String? path;
   if (comparer.sdk) {
@@ -72,8 +87,14 @@ class DartdocCompare {
   final bool sdk;
   final String markdownPath = File(Platform.script.path).parent.parent.path;
 
-  DartdocCompare(this.dartdocDir, this.markdownBefore, this.markdownAfter,
-      this.dartdocBin, this.dartdocPubspecPath, this.sdk);
+  DartdocCompare(
+    this.dartdocDir,
+    this.markdownBefore,
+    this.markdownAfter,
+    this.dartdocBin,
+    this.dartdocPubspecPath,
+    this.sdk,
+  );
 
   bool compare(String? package) {
     // Generate docs with Markdown "Before".

--- a/tool/expected_output.dart
+++ b/tool/expected_output.dart
@@ -8,8 +8,10 @@ import 'dart:isolate';
 import 'package:path/path.dart' as p;
 
 /// Parse and yield data cases (each a [DataCase]) from [path].
-Iterable<DataCase> dataCasesInFile(
-    {required String path, String? baseDir}) sync* {
+Iterable<DataCase> dataCasesInFile({
+  required String path,
+  String? baseDir,
+}) sync* {
   final file = p.basename(path).replaceFirst(RegExp(r'\..+$'), '');
   baseDir ??= p.relative(p.dirname(path), from: p.dirname(p.dirname(path)));
 
@@ -44,13 +46,14 @@ Iterable<DataCase> dataCasesInFile(
     }
 
     final dataCase = DataCase(
-        directory: baseDir,
-        file: file,
-        front_matter: frontMatter.toString(),
-        description: description,
-        skip: skip,
-        input: input,
-        expectedOutput: expectedOutput);
+      directory: baseDir,
+      file: file,
+      front_matter: frontMatter.toString(),
+      description: description,
+      skip: skip,
+      input: input,
+      expectedOutput: expectedOutput,
+    );
     yield dataCase;
   }
 }
@@ -118,13 +121,19 @@ Stream<DataCase> dataCasesUnder({
   String extension = 'unit',
   bool recursive = true,
 }) async* {
-  final markdownLibRoot = p.dirname((await Isolate.resolvePackageUri(
-          Uri.parse('package:markdown/markdown.dart')))!
-      .toFilePath());
+  final markdownLibRoot = p.dirname(
+    (await Isolate.resolvePackageUri(
+      Uri.parse('package:markdown/markdown.dart'),
+    ))!
+        .toFilePath(),
+  );
   final directory =
       p.joinAll([p.dirname(markdownLibRoot), 'test', testDirectory]);
   for (final dataCase in _dataCases(
-      directory: directory, extension: extension, recursive: recursive)) {
+    directory: directory,
+    extension: extension,
+    recursive: recursive,
+  )) {
     yield dataCase;
   }
 }

--- a/tool/stats.dart
+++ b/tool/stats.dart
@@ -19,22 +19,34 @@ final _configs =
 
 Future<void> main(List<String> args) async {
   final parser = ArgParser()
-    ..addOption('section',
-        help: 'Restrict tests to one section, provided after the option.')
-    ..addFlag('raw',
-        defaultsTo: false, help: 'raw JSON format', negatable: false)
-    ..addFlag('update-files',
-        defaultsTo: false,
-        help: 'Update stats files in $toolDir',
-        negatable: false)
-    ..addFlag('verbose',
-        defaultsTo: false,
-        help: 'Print details for failures and errors.',
-        negatable: false)
-    ..addFlag('verbose-loose',
-        defaultsTo: false,
-        help: 'Print details for "loose" matches.',
-        negatable: false)
+    ..addOption(
+      'section',
+      help: 'Restrict tests to one section, provided after the option.',
+    )
+    ..addFlag(
+      'raw',
+      defaultsTo: false,
+      help: 'raw JSON format',
+      negatable: false,
+    )
+    ..addFlag(
+      'update-files',
+      defaultsTo: false,
+      help: 'Update stats files in $toolDir',
+      negatable: false,
+    )
+    ..addFlag(
+      'verbose',
+      defaultsTo: false,
+      help: 'Print details for failures and errors.',
+      negatable: false,
+    )
+    ..addFlag(
+      'verbose-loose',
+      defaultsTo: false,
+      help: 'Print details for "loose" matches.',
+      negatable: false,
+    )
     ..addOption('flavor', allowed: _configs.map((c) => c.prefix))
     ..addFlag('help', defaultsTo: false, negatable: false);
 
@@ -76,17 +88,27 @@ Future<void> main(List<String> args) async {
       testPrefix == null ? _configs.map((c) => c.prefix) : <String>[testPrefix];
 
   for (final testPrefix in testPrefixes) {
-    await _processConfig(testPrefix, raw, updateFiles, verbose,
-        specifiedSection, verboseLooseMatch);
+    await _processConfig(
+      testPrefix,
+      raw,
+      updateFiles,
+      verbose,
+      specifiedSection,
+      verboseLooseMatch,
+    );
   }
 }
 
 final _sectionNameReplace = RegExp(r'[ \)\(]+');
 
-String _unitOutput(Iterable<DataCase> cases) => cases.map((dataCase) => '''
+String _unitOutput(Iterable<DataCase> cases) => cases
+    .map(
+      (dataCase) => '''
 >>> ${dataCase.front_matter}
 ${dataCase.input}<<<
-${dataCase.expectedOutput}''').join();
+${dataCase.expectedOutput}''',
+    )
+    .join();
 
 /// Set this to `true` and rerun `--update-files` to ease finding easy strict
 /// fixes.
@@ -105,7 +127,8 @@ Future<void> _processConfig(
   final sections = loadCommonMarkSections(testPrefix);
 
   final scores = SplayTreeMap<String, SplayTreeMap<int, CompareLevel>>(
-      compareAsciiLowerCaseNatural);
+    compareAsciiLowerCaseNatural,
+  );
 
   for (final entry in sections.entries) {
     if (specifiedSection != null && entry.key != specifiedSection) {
@@ -115,20 +138,28 @@ Future<void> _processConfig(
     final units = <DataCase>[];
 
     for (final e in entry.value) {
-      final result = compareResult(config, e,
-          verboseFail: verbose, verboseLooseMatch: verboseLooseMatch);
+      final result = compareResult(
+        config,
+        e,
+        verboseFail: verbose,
+        verboseLooseMatch: verboseLooseMatch,
+      );
 
-      units.add(DataCase(
-        front_matter: result.testCase.toString(),
-        input: result.testCase.markdown,
-        expectedOutput:
-            (_improveStrict && result.compareLevel == CompareLevel.loose)
-                ? result.testCase.html
-                : result.result!,
-      ));
+      units.add(
+        DataCase(
+          front_matter: result.testCase.toString(),
+          input: result.testCase.markdown,
+          expectedOutput:
+              (_improveStrict && result.compareLevel == CompareLevel.loose)
+                  ? result.testCase.html
+                  : result.result!,
+        ),
+      );
 
       final nestedMap = scores.putIfAbsent(
-          entry.key, () => SplayTreeMap<int, CompareLevel>());
+        entry.key,
+        () => SplayTreeMap<int, CompareLevel>(),
+      );
       nestedMap[e.example] = result.compareLevel;
     }
 
@@ -180,8 +211,11 @@ Object? _convert(Object? obj) {
   return obj;
 }
 
-Future<void> _printRaw(String testPrefix,
-    Map<String, Map<int, CompareLevel>> scores, bool updateFiles) async {
+Future<void> _printRaw(
+  String testPrefix,
+  Map<String, Map<int, CompareLevel>> scores,
+  bool updateFiles,
+) async {
   IOSink sink;
   if (updateFiles) {
     final file = getStatsFile(testPrefix);
@@ -210,9 +244,10 @@ String _pct(int value, int total, String section) =>
     '– ${(100 * value / total).toStringAsFixed(1).padLeft(5)}%  $section';
 
 Future<void> _printFriendly(
-    String testPrefix,
-    SplayTreeMap<String, SplayTreeMap<int, CompareLevel>> scores,
-    bool updateFiles) async {
+  String testPrefix,
+  SplayTreeMap<String, SplayTreeMap<int, CompareLevel>> scores,
+  bool updateFiles,
+) async {
   var totalValid = 0;
   var totalStrict = 0;
   var totalExamples = 0;

--- a/tool/stats_lib.dart
+++ b/tool/stats_lib.dart
@@ -15,18 +15,20 @@ import '../test/util.dart';
 
 // Locate the "tool" directory. Use mirrors so that this works with the test
 // package, which loads this suite into an isolate.
-String get toolDir =>
-    p.dirname((reflect(loadCommonMarkSections) as ClosureMirror)
-        .function
-        .location!
-        .sourceUri
-        .path);
+String get toolDir => p.dirname(
+      (reflect(loadCommonMarkSections) as ClosureMirror)
+          .function
+          .location!
+          .sourceUri
+          .path,
+    );
 
 File getStatsFile(String prefix) =>
     File(p.join(toolDir, '${prefix}_stats.json'));
 
 Map<String, List<CommonMarkTestCase>> loadCommonMarkSections(
-    String testPrefix) {
+  String testPrefix,
+) {
   final testFile = File(p.join(toolDir, '${testPrefix}_tests.json'));
   final testsJson = testFile.readAsStringSync();
 
@@ -48,10 +50,16 @@ Map<String, List<CommonMarkTestCase>> loadCommonMarkSections(
 }
 
 class Config {
-  static final Config commonMarkConfig =
-      Config._('common_mark', 'http://spec.commonmark.org/0.28/', null);
+  static final Config commonMarkConfig = Config._(
+    'common_mark',
+    'http://spec.commonmark.org/0.28/',
+    null,
+  );
   static final Config gfmConfig = Config._(
-      'gfm', 'https://github.github.com/gfm/', ExtensionSet.gitHubFlavored);
+    'gfm',
+    'https://github.github.com/gfm/',
+    ExtensionSet.gitHubFlavored,
+  );
 
   final String prefix;
   final String baseUrl;
@@ -68,17 +76,24 @@ class CommonMarkTestCase {
   final int startLine;
   final int endLine;
 
-  CommonMarkTestCase(this.example, this.section, this.startLine, this.endLine,
-      this.markdown, this.html);
+  CommonMarkTestCase(
+    this.example,
+    this.section,
+    this.startLine,
+    this.endLine,
+    this.markdown,
+    this.html,
+  );
 
   factory CommonMarkTestCase.fromJson(Map<String, dynamic> json) {
     return CommonMarkTestCase(
-        json['example'] as int,
-        json['section'] as String /*!*/,
-        json['start_line'] as int,
-        json['end_line'] as int,
-        json['markdown'] as String /*!*/,
-        json['html'] as String);
+      json['example'] as int,
+      json['section'] as String /*!*/,
+      json['start_line'] as int,
+      json['end_line'] as int,
+      json['markdown'] as String /*!*/,
+      json['html'] as String,
+    );
   }
 
   @override
@@ -95,21 +110,30 @@ class CompareResult {
   CompareResult(this.testCase, this.result, this.compareLevel);
 }
 
-CompareResult compareResult(Config config, CommonMarkTestCase testCase,
-    {bool throwOnError = false,
-    bool verboseFail = false,
-    bool verboseLooseMatch = false}) {
+CompareResult compareResult(
+  Config config,
+  CommonMarkTestCase testCase, {
+  bool throwOnError = false,
+  bool verboseFail = false,
+  bool verboseLooseMatch = false,
+}) {
   String output;
   try {
-    output =
-        markdownToHtml(testCase.markdown, extensionSet: config.extensionSet);
+    output = markdownToHtml(
+      testCase.markdown,
+      extensionSet: config.extensionSet,
+    );
   } catch (err, stackTrace) {
     if (throwOnError) {
       rethrow;
     }
     if (verboseFail) {
       _printVerboseFailure(
-          config.baseUrl, 'ERROR', testCase, 'Thrown: $err\n$stackTrace');
+        config.baseUrl,
+        'ERROR',
+        testCase,
+        'Thrown: $err\n$stackTrace',
+      );
     }
 
     return CompareResult(testCase, null, CompareLevel.error);
@@ -133,16 +157,25 @@ CompareResult compareResult(Config config, CommonMarkTestCase testCase,
   }
 
   return CompareResult(
-      testCase, output, looseMatch ? CompareLevel.loose : CompareLevel.fail);
+    testCase,
+    output,
+    looseMatch ? CompareLevel.loose : CompareLevel.fail,
+  );
 }
 
 String _indent(String s) =>
     s.splitMapJoin('\n', onNonMatch: (n) => '    ${whitespaceColor(n)}');
 
-void _printVerboseFailure(String baseUrl, String message,
-    CommonMarkTestCase testCase, String actual) {
-  print('$message: $baseUrl#example-${testCase.example} '
-      '@ ${testCase.section}');
+void _printVerboseFailure(
+  String baseUrl,
+  String message,
+  CommonMarkTestCase testCase,
+  String actual,
+) {
+  print(
+    '$message: $baseUrl#example-${testCase.example} '
+    '@ ${testCase.section}',
+  );
   print('input:');
   print(_indent(testCase.markdown));
   print('expected:');
@@ -154,7 +187,9 @@ void _printVerboseFailure(String baseUrl, String message,
 
 /// Compare two DOM trees for equality.
 bool _compareHtml(
-    List<Element> expectedElements, List<Element> actualElements) {
+  List<Element> expectedElements,
+  List<Element> actualElements,
+) {
   if (expectedElements.length != actualElements.length) {
     return false;
   }

--- a/tool/update_blns.dart
+++ b/tool/update_blns.dart
@@ -12,15 +12,15 @@ Future<void> main() async {
   try {
     final request = await client.getUrl(Uri.parse(_blnsJsonRawUrl));
     final response = await request.close();
-    json = (jsonDecode(await response
-            .cast<List<int>>()
-            .transform(utf8.decoder)
-            .join('')) as List)
+    json = (jsonDecode(
+      await response.cast<List<int>>().transform(utf8.decoder).join(''),
+    ) as List)
         .cast<String>();
   } finally {
     client.close();
   }
-  final blnsContent = StringBuffer('''
+  final blnsContent = StringBuffer(
+    '''
 // GENERATED FILE. DO NOT EDIT.
 //
 // This file was generated from big-list-of-naughty-strings's JSON file:
@@ -29,7 +29,8 @@ Future<void> main() async {
 
 // ignore_for_file: text_direction_code_point_in_literal, use_raw_strings
 
-''');
+''',
+  );
   blnsContent.writeln('const blns = <String>[');
   for (final str in json) {
     final escaped = str

--- a/tool/update_emojis.dart
+++ b/tool/update_emojis.dart
@@ -14,18 +14,25 @@ Future<void> main() async {
   final request = await client.getUrl(Uri.parse(_emojisJsonRawUrl));
   final response = await request.close();
   final json = jsonDecode(
-          await response.cast<List<int>>().transform(utf8.decoder).join(''))
-      .map((String alias, dynamic info) =>
-          MapEntry(alias, info.cast<String, dynamic>()))
+    await response.cast<List<int>>().transform(utf8.decoder).join(''),
+  )
+      .map(
+        (String alias, dynamic info) => MapEntry(
+          alias,
+          info.cast<String, dynamic>(),
+        ),
+      )
       .cast<String, Map<String, dynamic>>();
-  final emojisContent = StringBuffer('''
+  final emojisContent = StringBuffer(
+    '''
 // GENERATED FILE. DO NOT EDIT.
 //
 // This file was generated from emojilib's emoji data file:
 // $_emojisJsonRawUrl
 // at ${DateTime.now()} by the script, tool/update_emojis.dart.
 
-''');
+''',
+  );
   emojisContent.writeln('const emojis = <String, String>{');
   var emojiCount = 0;
   final ignored = <String>[];
@@ -39,7 +46,9 @@ Future<void> main() async {
   });
   emojisContent.writeln('};');
   File(_emojisFilePath).writeAsStringSync(emojisContent.toString());
-  print('Wrote data to $_emojisFilePath for $emojiCount emojis, '
-      'ignoring ${ignored.length}: ${ignored.join(', ')}.');
+  print(
+    'Wrote data to $_emojisFilePath for $emojiCount emojis, '
+    'ignoring ${ignored.length}: ${ignored.join(', ')}.',
+  );
   exit(0);
 }


### PR DESCRIPTION
Add this optional trailing commas to parameter lists to get good formatting. It is also recommended in [Flutter: Using trailing commas
](https://docs.flutter.dev/development/tools/formatting#using-trailing-commas)