### PR TITLE
Enable sort_constructors_first lint rule

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -36,3 +36,4 @@ linter:
     - use_raw_strings
     - unnecessary_raw_strings
     - prefer_interpolation_to_compose_strings
+    - sort_constructors_first

--- a/lib/src/ast.dart
+++ b/lib/src/ast.dart
@@ -15,11 +15,6 @@ abstract class Node {
 
 /// A named tag that can contain other nodes.
 class Element implements Node {
-  final String tag;
-  final List<Node>? children;
-  final Map<String, String> attributes;
-  String? generatedId;
-
   /// Instantiates a [tag] Element with [children].
   Element(this.tag, this.children) : attributes = <String, String>{};
 
@@ -37,6 +32,11 @@ class Element implements Node {
   Element.text(this.tag, String text)
       : children = [Text(text)],
         attributes = {};
+
+  final String tag;
+  final List<Node>? children;
+  final Map<String, String> attributes;
+  String? generatedId;
 
   /// Whether this element is self-closing.
   bool get isEmpty => children == null;
@@ -61,9 +61,9 @@ class Element implements Node {
 
 /// A plain text element.
 class Text implements Node {
-  final String text;
-
   Text(this.text);
+
+  final String text;
 
   @override
   void accept(NodeVisitor visitor) => visitor.visitText(this);
@@ -79,10 +79,10 @@ class Text implements Node {
 /// of a document are still being parsed, in order to gather all reference link
 /// definitions.
 class UnparsedContent implements Node {
+  UnparsedContent(this.textContent);
+
   @override
   final String textContent;
-
-  UnparsedContent(this.textContent);
 
   @override
   void accept(NodeVisitor visitor) {}

--- a/lib/src/document.dart
+++ b/lib/src/document.dart
@@ -9,28 +9,6 @@ import 'inline_parser.dart';
 
 /// Maintains the context needed to parse a Markdown document.
 class Document {
-  final Map<String, LinkReference> linkReferences = <String, LinkReference>{};
-  final Resolver? linkResolver;
-  final Resolver? imageLinkResolver;
-  final bool encodeHtml;
-
-  /// Whether to use default block syntaxes.
-  final bool withDefaultBlockSyntaxes;
-
-  /// Whether to use default inline syntaxes.
-  ///
-  /// Need to set both [withDefaultInlineSyntaxes] and [encodeHtml] to
-  /// `false` to disable all inline syntaxes including html encoding syntaxes.
-  final bool withDefaultInlineSyntaxes;
-
-  final _blockSyntaxes = <BlockSyntax>{};
-  final _inlineSyntaxes = <InlineSyntax>{};
-  final bool hasCustomInlineSyntaxes;
-
-  Iterable<BlockSyntax> get blockSyntaxes => _blockSyntaxes;
-
-  Iterable<InlineSyntax> get inlineSyntaxes => _inlineSyntaxes;
-
   Document({
     Iterable<BlockSyntax>? blockSyntaxes,
     Iterable<InlineSyntax>? inlineSyntaxes,
@@ -58,6 +36,28 @@ class Document {
       _inlineSyntaxes.addAll(extensionSet.inlineSyntaxes);
     }
   }
+
+  final Map<String, LinkReference> linkReferences = <String, LinkReference>{};
+  final Resolver? linkResolver;
+  final Resolver? imageLinkResolver;
+  final bool encodeHtml;
+
+  /// Whether to use default block syntaxes.
+  final bool withDefaultBlockSyntaxes;
+
+  /// Whether to use default inline syntaxes.
+  ///
+  /// Need to set both [withDefaultInlineSyntaxes] and [encodeHtml] to
+  /// `false` to disable all inline syntaxes including html encoding syntaxes.
+  final bool withDefaultInlineSyntaxes;
+
+  final _blockSyntaxes = <BlockSyntax>{};
+  final _inlineSyntaxes = <InlineSyntax>{};
+  final bool hasCustomInlineSyntaxes;
+
+  Iterable<BlockSyntax> get blockSyntaxes => _blockSyntaxes;
+
+  Iterable<InlineSyntax> get inlineSyntaxes => _inlineSyntaxes;
 
   /// Parses the given [lines] of Markdown to a series of AST nodes.
   List<Node> parseLines(List<String> lines) {
@@ -87,6 +87,12 @@ class Document {
 /// A [link reference
 /// definition](http://spec.commonmark.org/0.28/#link-reference-definitions).
 class LinkReference {
+  /// Construct a new [LinkReference], with all necessary fields.
+  ///
+  /// If the parsed link reference definition does not include a title, use
+  /// `null` for the [title] parameter.
+  LinkReference(this.label, this.destination, this.title);
+
   /// The [link label](http://spec.commonmark.org/0.28/#link-label).
   ///
   /// Temporarily, this class is also being used to represent the link data for
@@ -99,10 +105,4 @@ class LinkReference {
 
   /// The [link title](http://spec.commonmark.org/0.28/#link-title).
   final String? title;
-
-  /// Construct a new [LinkReference], with all necessary fields.
-  ///
-  /// If the parsed link reference definition does not include a title, use
-  /// `null` for the [title] parameter.
-  LinkReference(this.label, this.destination, this.title);
 }

--- a/lib/src/extension_set.dart
+++ b/lib/src/extension_set.dart
@@ -7,6 +7,8 @@ import 'inline_parser.dart';
 /// For example, the [gitHubFlavored] set of syntax extensions allows users to
 /// output HTML from their Markdown in a similar fashion to GitHub's parsing.
 class ExtensionSet {
+  ExtensionSet(this.blockSyntaxes, this.inlineSyntaxes);
+
   /// The [ExtensionSet.none] extension set renders Markdown similar to
   /// [Markdown.pl].
   ///
@@ -80,6 +82,4 @@ class ExtensionSet {
 
   final List<BlockSyntax> blockSyntaxes;
   final List<InlineSyntax> inlineSyntaxes;
-
-  ExtensionSet(this.blockSyntaxes, this.inlineSyntaxes);
 }

--- a/lib/src/html_renderer.dart
+++ b/lib/src/html_renderer.dart
@@ -82,13 +82,13 @@ const _blockTags = [
 
 /// Translates a parsed AST to HTML.
 class HtmlRenderer implements NodeVisitor {
+  HtmlRenderer();
+
   late StringBuffer buffer;
   late Set<String> uniqueIds;
 
   final _elementStack = <Element>[];
   String? _lastVisitedTag;
-
-  HtmlRenderer();
 
   String render(List<Node> nodes) {
     buffer = StringBuffer();

--- a/lib/src/inline_parser.dart
+++ b/lib/src/inline_parser.dart
@@ -12,6 +12,37 @@ import 'util.dart';
 /// Maintains the internal state needed to parse inline span elements in
 /// Markdown.
 class InlineParser {
+  InlineParser(this.source, this.document) {
+    // User specified syntaxes are the first syntaxes to be evaluated.
+    syntaxes.addAll(document.inlineSyntaxes);
+
+    // This first RegExp matches plain text to accelerate parsing. It's written
+    // so that it does not match any prefix of any following syntaxes. Most
+    // Markdown is plain text, so it's faster to match one RegExp per 'word'
+    // rather than fail to match all the following RegExps at each non-syntax
+    // character position.
+    if (document.hasCustomInlineSyntaxes) {
+      // We should be less aggressive in blowing past "words".
+      syntaxes.add(TextSyntax(r'[A-Za-z0-9]+(?=\s)'));
+    } else {
+      syntaxes.add(TextSyntax(r'[ \tA-Za-z0-9]*[A-Za-z0-9](?=\s)'));
+    }
+
+    if (document.withDefaultInlineSyntaxes) {
+      // Custom link resolvers go after the generic text syntax.
+      syntaxes.addAll([
+        LinkSyntax(linkResolver: document.linkResolver),
+        ImageSyntax(linkResolver: document.imageLinkResolver)
+      ]);
+
+      syntaxes.addAll(_defaultSyntaxes);
+    }
+
+    if (_encodeHtml) {
+      syntaxes.addAll(_htmlSyntaxes);
+    }
+  }
+
   static final List<InlineSyntax> _defaultSyntaxes =
       List<InlineSyntax>.unmodifiable(<InlineSyntax>[
     EmailAutolinkSyntax(),
@@ -64,37 +95,6 @@ class InlineParser {
 
   /// The tree of parsed HTML nodes.
   final _tree = <Node>[];
-
-  InlineParser(this.source, this.document) {
-    // User specified syntaxes are the first syntaxes to be evaluated.
-    syntaxes.addAll(document.inlineSyntaxes);
-
-    // This first RegExp matches plain text to accelerate parsing. It's written
-    // so that it does not match any prefix of any following syntaxes. Most
-    // Markdown is plain text, so it's faster to match one RegExp per 'word'
-    // rather than fail to match all the following RegExps at each non-syntax
-    // character position.
-    if (document.hasCustomInlineSyntaxes) {
-      // We should be less aggressive in blowing past "words".
-      syntaxes.add(TextSyntax(r'[A-Za-z0-9]+(?=\s)'));
-    } else {
-      syntaxes.add(TextSyntax(r'[ \tA-Za-z0-9]*[A-Za-z0-9](?=\s)'));
-    }
-
-    if (document.withDefaultInlineSyntaxes) {
-      // Custom link resolvers go after the generic text syntax.
-      syntaxes.addAll([
-        LinkSyntax(linkResolver: document.linkResolver),
-        ImageSyntax(linkResolver: document.imageLinkResolver)
-      ]);
-
-      syntaxes.addAll(_defaultSyntaxes);
-    }
-
-    if (_encodeHtml) {
-      syntaxes.addAll(_htmlSyntaxes);
-    }
-  }
 
   List<Node> parse() {
     while (!isDone) {
@@ -356,12 +356,6 @@ class InlineParser {
 
 /// Represents one kind of Markdown tag that can be parsed.
 abstract class InlineSyntax {
-  final RegExp pattern;
-
-  /// The first character of [pattern], to be used as an efficient first check
-  /// that this syntax matches the current parser position.
-  final int? _startCharacter;
-
   /// Create a new [InlineSyntax] which matches text on [pattern].
   ///
   /// If [startCharacter] is passed, it is used as a pre-matching check which
@@ -373,6 +367,12 @@ abstract class InlineSyntax {
       : pattern =
             RegExp(pattern, multiLine: true, caseSensitive: caseSensitive),
         _startCharacter = startCharacter;
+
+  final RegExp pattern;
+
+  /// The first character of [pattern], to be used as an efficient first check
+  /// that this syntax matches the current parser position.
+  final int? _startCharacter;
 
   /// Tries to match at the parser's current position.
   ///
@@ -420,8 +420,6 @@ class LineBreakSyntax extends InlineSyntax {
 
 /// Matches stuff that should just be passed through as straight text.
 class TextSyntax extends InlineSyntax {
-  final String substitute;
-
   /// Create a new [TextSyntax] which matches text on [pattern].
   ///
   /// If [sub] is passed, it is used as a simple replacement for [pattern]. If
@@ -430,6 +428,8 @@ class TextSyntax extends InlineSyntax {
   TextSyntax(String pattern, {String sub = '', int? startCharacter})
       : substitute = sub,
         super(pattern, startCharacter: startCharacter);
+
+  final String substitute;
 
   /// Adds a [Text] node to [parser] and returns `true` if there is a
   /// [substitute], as long as the preceding character (if any) is not a `/`.
@@ -502,11 +502,11 @@ class InlineHtmlSyntax extends TextSyntax {
 ///
 /// See <http://spec.commonmark.org/0.28/#email-address>.
 class EmailAutolinkSyntax extends InlineSyntax {
+  EmailAutolinkSyntax() : super('<($_email)>', startCharacter: $lt);
+
   static final _email =
       r'''[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}'''
       r'''[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*''';
-
-  EmailAutolinkSyntax() : super('<($_email)>', startCharacter: $lt);
 
   @override
   bool onMatch(InlineParser parser, Match match) {
@@ -538,6 +538,8 @@ class AutolinkSyntax extends InlineSyntax {
 
 /// Matches autolinks like `http://foo.com`.
 class AutolinkExtensionSyntax extends InlineSyntax {
+  AutolinkExtensionSyntax() : super('$start(($scheme)($domain)($path))');
+
   /// Broken up parts of the autolink regex for reusability and readability
 
   // Autolinks can only come at the beginning of a line, after whitespace, or
@@ -565,8 +567,6 @@ class AutolinkExtensionSyntax extends InlineSyntax {
   static final regExpTrailingPunc = RegExp('$truncatingPunctuationPositive*\$');
   static final regExpEndsWithColon = RegExp(r'\&[a-zA-Z0-9]+;$');
   static final regExpWhiteSpace = RegExp(r'\s');
-
-  AutolinkExtensionSyntax() : super('$start(($scheme)($domain)($path))');
 
   @override
   bool tryMatch(InlineParser parser, [int? startMatchPos]) {
@@ -704,6 +704,16 @@ abstract class Delimiter {
 /// A simple delimiter implements the [Delimiter] interface with basic fields,
 /// and does not have the concept of "left-flanking" or "right-flanking".
 class SimpleDelimiter implements Delimiter {
+  SimpleDelimiter({
+    required this.node,
+    required this.char,
+    required this.length,
+    required this.canOpen,
+    required this.canClose,
+    required this.syntax,
+    required this.endPos,
+  }) : isActive = true;
+
   @override
   Text node;
 
@@ -726,16 +736,6 @@ class SimpleDelimiter implements Delimiter {
   final DelimiterSyntax syntax;
 
   final int endPos;
-
-  SimpleDelimiter({
-    required this.node,
-    required this.char,
-    required this.length,
-    required this.canOpen,
-    required this.canClose,
-    required this.syntax,
-    required this.endPos,
-  }) : isActive = true;
 }
 
 /// An implementation of [Delimiter] which uses concepts of "left-flanking" and
@@ -744,6 +744,22 @@ class SimpleDelimiter implements Delimiter {
 /// This is primarily used when parsing emphasis and strong emphasis, but can
 /// also be used by other extensions of [DelimiterSyntax].
 class DelimiterRun implements Delimiter {
+  DelimiterRun._({
+    required this.node,
+    required this.char,
+    required this.syntax,
+    required this.tags,
+    required bool isLeftFlanking,
+    required bool isRightFlanking,
+    required bool isPrecededByPunctuation,
+    required bool isFollowedByPunctuation,
+    required this.allowIntraWord,
+  })  : canOpen = isLeftFlanking &&
+            (!isRightFlanking || allowIntraWord || isPrecededByPunctuation),
+        canClose = isRightFlanking &&
+            (!isLeftFlanking || allowIntraWord || isFollowedByPunctuation),
+        isActive = true;
+
   /// According to
   /// [CommonMark](https://spec.commonmark.org/0.29/#punctuation-character):
   ///
@@ -803,22 +819,6 @@ class DelimiterRun implements Delimiter {
   final bool canClose;
 
   final List<DelimiterTag> tags;
-
-  DelimiterRun._({
-    required this.node,
-    required this.char,
-    required this.syntax,
-    required this.tags,
-    required bool isLeftFlanking,
-    required bool isRightFlanking,
-    required bool isPrecededByPunctuation,
-    required bool isFollowedByPunctuation,
-    required this.allowIntraWord,
-  })  : canOpen = isLeftFlanking &&
-            (!isRightFlanking || allowIntraWord || isPrecededByPunctuation),
-        canClose = isRightFlanking &&
-            (!isLeftFlanking || allowIntraWord || isFollowedByPunctuation),
-        isActive = true;
 
   /// Tries to parse a delimiter run from [runStart] (inclusive) to [runEnd]
   /// (exclusive).
@@ -907,19 +907,6 @@ class DelimiterTag {
 /// Matches syntax that has a pair of tags and becomes an element, like `*` for
 /// `<em>`. Allows nested tags.
 class DelimiterSyntax extends InlineSyntax {
-  /// Whether this is parsed according to the same nesting rules as [emphasis
-  /// delimiters][].
-  ///
-  /// [emphasis delimiters]: http://spec.commonmark.org/0.28/#can-open-emphasis
-  final bool requiresDelimiterRun;
-
-  /// Whether to allow intra-word delimiter runs. CommonMark emphasis and
-  /// strong emphasis does not allow this, but GitHub-Flavored Markdown allows
-  /// it on strikethrough.
-  final bool allowIntraWord;
-
-  final List<DelimiterTag>? tags;
-
   /// Creates a new [DelimiterSyntax] which matches text on [pattern].
   ///
   /// The [pattern] is used to find the matching text. If [requiresDelimiterRun]
@@ -933,6 +920,19 @@ class DelimiterSyntax extends InlineSyntax {
     this.allowIntraWord = false,
     this.tags,
   }) : super(pattern, startCharacter: startCharacter);
+
+  /// Whether this is parsed according to the same nesting rules as [emphasis
+  /// delimiters][].
+  ///
+  /// [emphasis delimiters]: http://spec.commonmark.org/0.28/#can-open-emphasis
+  final bool requiresDelimiterRun;
+
+  /// Whether to allow intra-word delimiter runs. CommonMark emphasis and
+  /// strong emphasis does not allow this, but GitHub-Flavored Markdown allows
+  /// it on strikethrough.
+  final bool allowIntraWord;
+
+  final List<DelimiterTag>? tags;
 
   @override
   bool onMatch(InlineParser parser, Match match) {
@@ -1029,16 +1029,16 @@ class TagSyntax extends DelimiterSyntax {
 
 /// Matches links like `[blah][label]` and `[blah](url)`.
 class LinkSyntax extends DelimiterSyntax {
-  static final _entirelyWhitespacePattern = RegExp(r'^\s*$');
-
-  final Resolver linkResolver;
-
   LinkSyntax({
     Resolver? linkResolver,
     String pattern = r'\[',
     int startCharacter = $lbracket,
   })  : linkResolver = (linkResolver ?? ((String _, [String? __]) => null)),
         super(pattern, startCharacter: startCharacter);
+
+  static final _entirelyWhitespacePattern = RegExp(r'^\s*$');
+
+  final Resolver linkResolver;
 
   @override
   Node? close(
@@ -1485,6 +1485,8 @@ class ImageSyntax extends LinkSyntax {
 
 /// Matches backtick-enclosed inline code blocks.
 class CodeSyntax extends InlineSyntax {
+  CodeSyntax() : super(_pattern);
+
   // This pattern matches:
   //
   // * a string of backticks (not followed by any more), followed by
@@ -1496,8 +1498,6 @@ class CodeSyntax extends InlineSyntax {
   // This conforms to the delimiters of inline code, both in Markdown.pl, and
   // CommonMark.
   static final String _pattern = r'(`+(?!`))((?:.|\n)*?[^`])\1(?!`)';
-
-  CodeSyntax() : super(_pattern);
 
   @override
   bool tryMatch(InlineParser parser, [int? startMatchPos]) {
@@ -1554,8 +1554,8 @@ class EmojiSyntax extends InlineSyntax {
 }
 
 class InlineLink {
+  InlineLink(this.destination, {this.title});
+
   final String destination;
   final String? title;
-
-  InlineLink(this.destination, {this.title});
 }

--- a/tool/dartdoc_compare.dart
+++ b/tool/dartdoc_compare.dart
@@ -72,14 +72,6 @@ void main(List<String> arguments) {
 }
 
 class DartdocCompare {
-  final String dartdocDir;
-  final String markdownBefore;
-  final String markdownAfter;
-  final String dartdocBin;
-  final String dartdocPubspecPath;
-  final bool sdk;
-  final String markdownPath = File(Platform.script.path).parent.parent.path;
-
   DartdocCompare(
     this.dartdocDir,
     this.markdownBefore,
@@ -88,6 +80,14 @@ class DartdocCompare {
     this.dartdocPubspecPath,
     this.sdk,
   );
+
+  final String dartdocDir;
+  final String markdownBefore;
+  final String markdownAfter;
+  final String dartdocBin;
+  final String dartdocPubspecPath;
+  final bool sdk;
+  final String markdownPath = File(Platform.script.path).parent.parent.path;
 
   bool compare(String? package) {
     // Generate docs with Markdown "Before".

--- a/tool/expected_output.dart
+++ b/tool/expected_output.dart
@@ -138,16 +138,6 @@ Stream<DataCase> dataCasesUnder({
 /// All of the data pertaining to a particular test case, namely the [input] and
 /// [expectedOutput].
 class DataCase {
-  final String directory;
-  final String file;
-
-  // ignore: non_constant_identifier_names
-  final String front_matter;
-  final String description;
-  final bool skip;
-  final String input;
-  final String expectedOutput;
-
   DataCase({
     this.directory = '',
     this.file = '',
@@ -158,6 +148,16 @@ class DataCase {
     required this.input,
     required this.expectedOutput,
   });
+
+  final String directory;
+  final String file;
+
+  // ignore: non_constant_identifier_names
+  final String front_matter;
+  final String description;
+  final bool skip;
+  final String input;
+  final String expectedOutput;
 
   /// A good standard description for `test()`, derived from the data directory,
   /// the particular data file, and the test case description.

--- a/tool/stats_lib.dart
+++ b/tool/stats_lib.dart
@@ -51,6 +51,8 @@ Map<String, List<CommonMarkTestCase>> loadCommonMarkSections(
 }
 
 class Config {
+  Config._(this.prefix, this.baseUrl, this.extensionSet);
+
   static final Config commonMarkConfig = Config._(
     'common_mark',
     'http://spec.commonmark.org/0.28/',
@@ -65,18 +67,9 @@ class Config {
   final String prefix;
   final String baseUrl;
   final ExtensionSet? extensionSet;
-
-  Config._(this.prefix, this.baseUrl, this.extensionSet);
 }
 
 class CommonMarkTestCase {
-  final String markdown;
-  final String section;
-  final int example;
-  final String html;
-  final int startLine;
-  final int endLine;
-
   CommonMarkTestCase(
     this.example,
     this.section,
@@ -97,6 +90,13 @@ class CommonMarkTestCase {
     );
   }
 
+  final String markdown;
+  final String section;
+  final int example;
+  final String html;
+  final int startLine;
+  final int endLine;
+
   @override
   String toString() => '$section - $example';
 }
@@ -104,11 +104,11 @@ class CommonMarkTestCase {
 enum CompareLevel { strict, loose, fail, error }
 
 class CompareResult {
+  CompareResult(this.testCase, this.result, this.compareLevel);
+
   final CompareLevel compareLevel;
   final CommonMarkTestCase testCase;
   final String? result;
-
-  CompareResult(this.testCase, this.result, this.compareLevel);
 }
 
 CompareResult compareResult(


### PR DESCRIPTION
It is a [Flutter style recommendation](https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#constructors-come-first-in-a-class). I think it also works in Dart.