### PR TITLE
Remove Element.empty() from AST

### DIFF
--- a/lib/src/ast.dart
+++ b/lib/src/ast.dart
@@ -16,38 +16,38 @@ abstract class Node {
 /// A named tag that can contain other nodes.
 class Element implements Node {
   final String tag;
-  final List<Node>? children;
+  final List<Node> children;
   final Map<String, String> attributes;
+
+  /// Whether this element is self-closing.
+  final bool selfClosing;
+
   String? generatedId;
-
-  /// Instantiates a [tag] Element with [children].
-  Element(this.tag, this.children) : attributes = <String, String>{};
-
-  /// Instantiates an empty, self-closing [tag] Element.
-  Element.empty(this.tag)
-      : children = null,
-        attributes = {};
 
   /// Instantiates a [tag] Element with no [children].
   Element.withTag(this.tag)
       : children = [],
+        selfClosing = false,
         attributes = {};
+
+  /// Instantiates a [tag] Element with [children].
+  Element(
+    this.tag, {
+    this.children = const [],
+    this.selfClosing = false,
+  }) : attributes = <String, String>{};
 
   /// Instantiates a [tag] Element with a single Text child.
   Element.text(this.tag, String text)
       : children = [Text(text)],
+        selfClosing = false,
         attributes = {};
-
-  /// Whether this element is self-closing.
-  bool get isEmpty => children == null;
 
   @override
   void accept(NodeVisitor visitor) {
     if (visitor.visitElementBefore(this)) {
-      if (children != null) {
-        for (var child in children!) {
-          child.accept(visitor);
-        }
+      for (var child in children) {
+        child.accept(visitor);
       }
       visitor.visitElementAfter(this);
     }
@@ -55,7 +55,7 @@ class Element implements Node {
 
   @override
   String get textContent {
-    return (children ?? []).map((child) => child.textContent).join('');
+    return children.map((child) => child.textContent).join('');
   }
 }
 

--- a/lib/src/block_syntaxes/block_syntax.dart
+++ b/lib/src/block_syntaxes/block_syntax.dart
@@ -42,7 +42,7 @@ abstract class BlockSyntax {
 
   /// Generates a valid HTML anchor from the inner text of [element].
   static String generateAnchorHash(Element element) =>
-      element.children!.first.textContent
+      element.children.first.textContent
           .toLowerCase()
           .trim()
           .replaceAll(RegExp('[^a-z0-9 _-]'), '')

--- a/lib/src/block_syntaxes/blockquote_syntax.dart
+++ b/lib/src/block_syntaxes/blockquote_syntax.dart
@@ -58,6 +58,6 @@ class BlockquoteSyntax extends BlockSyntax {
     // Recursively parse the contents of the blockquote.
     final children = BlockParser(childLines, parser.document).parseLines();
 
-    return Element('blockquote', children);
+    return Element('blockquote', children: children);
   }
 }

--- a/lib/src/block_syntaxes/code_block_syntax.dart
+++ b/lib/src/block_syntaxes/code_block_syntax.dart
@@ -57,6 +57,6 @@ class CodeBlockSyntax extends BlockSyntax {
       content = escapeHtml(content);
     }
 
-    return Element('pre', [Element.text('code', content)]);
+    return Element('pre', children: [Element.text('code', content)]);
   }
 }

--- a/lib/src/block_syntaxes/fenced_blockquote_syntax.dart
+++ b/lib/src/block_syntaxes/fenced_blockquote_syntax.dart
@@ -39,6 +39,6 @@ class FencedBlockquoteSyntax extends BlockSyntax {
 
     // Recursively parse the contents of the blockquote.
     final children = BlockParser(childLines, parser.document).parseLines();
-    return Element('blockquote', children);
+    return Element('blockquote', children: children);
   }
 }

--- a/lib/src/block_syntaxes/fenced_code_block_syntax.dart
+++ b/lib/src/block_syntaxes/fenced_code_block_syntax.dart
@@ -87,7 +87,7 @@ class FencedCodeBlockSyntax extends BlockSyntax {
       code.attributes['class'] = 'language-$infoString';
     }
 
-    final element = Element('pre', [code]);
+    final element = Element('pre', children: [code]);
 
     return element;
   }

--- a/lib/src/block_syntaxes/header_syntax.dart
+++ b/lib/src/block_syntaxes/header_syntax.dart
@@ -20,6 +20,6 @@ class HeaderSyntax extends BlockSyntax {
     parser.advance();
     final level = match[1]!.length;
     final contents = UnparsedContent(match[2]!.trim());
-    return Element('h$level', [contents]);
+    return Element('h$level', children: [contents]);
   }
 }

--- a/lib/src/block_syntaxes/horizontal_rule_syntax.dart
+++ b/lib/src/block_syntaxes/horizontal_rule_syntax.dart
@@ -17,6 +17,6 @@ class HorizontalRuleSyntax extends BlockSyntax {
   @override
   Node parse(BlockParser parser) {
     parser.advance();
-    return Element.empty('hr');
+    return Element('hr', selfClosing: true);
   }
 }

--- a/lib/src/block_syntaxes/list_syntax.dart
+++ b/lib/src/block_syntaxes/list_syntax.dart
@@ -156,7 +156,7 @@ abstract class ListSyntax extends BlockSyntax {
     for (final item in items) {
       final itemParser = BlockParser(item.lines, parser.document);
       final children = itemParser.parseLines();
-      itemNodes.add(Element('li', children));
+      itemNodes.add(Element('li', children: children));
       anyEmptyLinesBetweenBlocks =
           anyEmptyLinesBetweenBlocks || itemParser.encounteredBlankLine;
     }
@@ -170,22 +170,21 @@ abstract class ListSyntax extends BlockSyntax {
       // elements to just text elements.
       for (final item in itemNodes) {
         final children = item.children;
-        if (children != null) {
-          for (var i = 0; i < children.length; i++) {
-            final child = children[i];
-            if (child is Element && child.tag == 'p') {
-              children.removeAt(i);
-              children.insertAll(i, child.children!);
-            }
+        for (var i = 0; i < children.length; i++) {
+          final child = children[i];
+          if (child is Element && child.tag == 'p') {
+            children.removeAt(i);
+            children.insertAll(i, child.children);
           }
         }
       }
     }
 
     if (listTag == 'ol' && startNumber != 1) {
-      return Element(listTag, itemNodes)..attributes['start'] = '$startNumber';
+      return Element(listTag, children: itemNodes)
+        ..attributes['start'] = '$startNumber';
     } else {
-      return Element(listTag, itemNodes);
+      return Element(listTag, children: itemNodes);
     }
   }
 

--- a/lib/src/block_syntaxes/paragraph_syntax.dart
+++ b/lib/src/block_syntaxes/paragraph_syntax.dart
@@ -42,7 +42,7 @@ class ParagraphSyntax extends BlockSyntax {
       return Text('');
     } else {
       final contents = UnparsedContent(paragraphLines.join('\n').trimRight());
-      return Element('p', [contents]);
+      return Element('p', children: [contents]);
     }
   }
 

--- a/lib/src/block_syntaxes/setext_header_syntax.dart
+++ b/lib/src/block_syntaxes/setext_header_syntax.dart
@@ -56,7 +56,7 @@ class SetextHeaderSyntax extends BlockSyntax {
 
     final contents = UnparsedContent(lines.join('\n').trimRight());
 
-    return Element(tag!, [contents]);
+    return Element(tag!, children: [contents]);
   }
 
   bool _interperableAsParagraph(String line) =>

--- a/lib/src/block_syntaxes/table_syntax.dart
+++ b/lib/src/block_syntaxes/table_syntax.dart
@@ -35,10 +35,10 @@ class TableSyntax extends BlockSyntax {
     final alignments = _parseAlignments(parser.next!);
     final columnCount = alignments.length;
     final headRow = _parseRow(parser, alignments, 'th');
-    if (headRow.children!.length != columnCount) {
+    if (headRow.children.length != columnCount) {
       return null;
     }
-    final head = Element('thead', [headRow]);
+    final head = Element('thead', children: [headRow]);
 
     // Advance past the divider of hyphens.
     parser.advance();
@@ -47,26 +47,24 @@ class TableSyntax extends BlockSyntax {
     while (!parser.isDone && !BlockSyntax.isAtBlockEnd(parser)) {
       final row = _parseRow(parser, alignments, 'td');
       final children = row.children;
-      if (children != null) {
-        while (children.length < columnCount) {
-          // Insert synthetic empty cells.
-          children.add(Element.empty('td'));
-        }
-        while (children.length > columnCount) {
-          children.removeLast();
-        }
+      while (children.length < columnCount) {
+        // Insert synthetic empty cells.
+        children.add(Element('td', selfClosing: true));
       }
-      while (row.children!.length > columnCount) {
-        row.children!.removeLast();
+      while (children.length > columnCount) {
+        children.removeLast();
+      }
+      while (row.children.length > columnCount) {
+        row.children.removeLast();
       }
       rows.add(row);
     }
     if (rows.isEmpty) {
-      return Element('table', [head]);
+      return Element('table', children: [head]);
     } else {
-      final body = Element('tbody', rows);
+      final body = Element('tbody', children: rows);
 
-      return Element('table', [head, body]);
+      return Element('table', children: [head, body]);
     }
   }
 
@@ -161,7 +159,8 @@ class TableSyntax extends BlockSyntax {
     }
     parser.advance();
     final row = [
-      for (final cell in cells) Element(cellType, [UnparsedContent(cell)])
+      for (final cell in cells)
+        Element(cellType, children: [UnparsedContent(cell)])
     ];
 
     for (var i = 0; i < row.length && i < alignments.length; i++) {
@@ -169,7 +168,7 @@ class TableSyntax extends BlockSyntax {
       row[i].attributes['style'] = 'text-align: ${alignments[i]};';
     }
 
-    return Element('tr', row);
+    return Element('tr', children: row);
   }
 
   /// Walks past whitespace in [line] starting at [index].

--- a/lib/src/document.dart
+++ b/lib/src/document.dart
@@ -79,8 +79,8 @@ class Document {
         nodes.removeAt(i);
         nodes.insertAll(i, inlineNodes);
         i += inlineNodes.length - 1;
-      } else if (node is Element && node.children != null) {
-        _parseInlineContent(node.children!);
+      } else if (node is Element && !node.selfClosing) {
+        _parseInlineContent(node.children);
       }
     }
   }

--- a/lib/src/html_renderer.dart
+++ b/lib/src/html_renderer.dart
@@ -140,7 +140,7 @@ class HtmlRenderer implements NodeVisitor {
 
     _lastVisitedTag = element.tag;
 
-    if (element.isEmpty) {
+    if (element.selfClosing) {
       // Empty element like <hr/>.
       buffer.write(' />');
 
@@ -160,8 +160,8 @@ class HtmlRenderer implements NodeVisitor {
   void visitElementAfter(Element element) {
     assert(identical(_elementStack.last, element));
 
-    if (element.children != null &&
-        element.children!.isNotEmpty &&
+    if (!element.selfClosing &&
+        element.children.isNotEmpty &&
         _blockTags.contains(_lastVisitedTag) &&
         _blockTags.contains(element.tag)) {
       buffer.writeln();

--- a/lib/src/inline_parser.dart
+++ b/lib/src/inline_parser.dart
@@ -311,8 +311,8 @@ class InlineParser {
   void _combineAdjacentText(List<Node> nodes) {
     for (var i = 0; i < nodes.length - 1; i++) {
       final node = nodes[i];
-      if (node is Element && node.children != null) {
-        _combineAdjacentText(node.children!);
+      if (node is Element && !node.selfClosing) {
+        _combineAdjacentText(node.children);
         continue;
       }
       if (node is Text && nodes[i + 1] is Text) {

--- a/lib/src/inline_syntaxes/delimiter_syntax.dart
+++ b/lib/src/inline_syntaxes/delimiter_syntax.dart
@@ -91,7 +91,7 @@ class DelimiterSyntax extends InlineSyntax {
     required String tag,
     required List<Node> Function() getChildren,
   }) {
-    return Element(tag, getChildren());
+    return Element(tag, children: getChildren());
   }
 }
 

--- a/lib/src/inline_syntaxes/image_syntax.dart
+++ b/lib/src/inline_syntaxes/image_syntax.dart
@@ -23,7 +23,7 @@ class ImageSyntax extends LinkSyntax {
     String? title, {
     required List<Node> Function() getChildren,
   }) {
-    final element = Element.empty('img');
+    final element = Element('img', selfClosing: true);
     final children = getChildren();
     element.attributes['src'] = destination;
     element.attributes['alt'] = children.map((node) => node.textContent).join();

--- a/lib/src/inline_syntaxes/line_break_syntax.dart
+++ b/lib/src/inline_syntaxes/line_break_syntax.dart
@@ -13,7 +13,7 @@ class LineBreakSyntax extends InlineSyntax {
   /// Create a void <br> element.
   @override
   bool onMatch(InlineParser parser, Match match) {
-    parser.addNode(Element.empty('br'));
+    parser.addNode(Element('br', selfClosing: true));
     return true;
   }
 }

--- a/lib/src/inline_syntaxes/link_syntax.dart
+++ b/lib/src/inline_syntaxes/link_syntax.dart
@@ -138,7 +138,7 @@ class LinkSyntax extends DelimiterSyntax {
     required List<Node> Function() getChildren,
   }) {
     final children = getChildren();
-    final element = Element('a', children);
+    final element = Element('a', children: children);
     element.attributes['href'] = escapeAttribute(destination);
     if (title != null && title.isNotEmpty) {
       element.attributes['title'] = escapeAttribute(title);

--- a/test/html_renderer_test.dart
+++ b/test/html_renderer_test.dart
@@ -111,7 +111,7 @@ class _BreakSyntax extends InlineSyntax {
 
   @override
   bool onMatch(InlineParser parser, Match match) {
-    parser.addNode(Element.empty('break'));
+    parser.addNode(Element('break', selfClosing: true));
     return true;
   }
 }


### PR DESCRIPTION
Remove `Element.empty()` which instantiates a **self-closing** tag Element and add a property `selfClosing` to represent if it is a  **self-closing** tag. 

Because if this [AST enhancement proposal]( https://github.com/dart-lang/markdown/pull/413
) is accepted, the `children` of `Element` will never be empty, it will at least have `Helper` child.

Also the current naming is ambiguous, for example:
```dart
/// Whether this element is self-closing.
bool get isEmpty => children == null;
 ```
as there are also some scenarios that need to check if `children` is empty