### PR TITLE
Remove dependency on package:charcode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.1.4-dev
+
 ## 2.1.3
 
 * Do not encode HTML in link URLs. Also do not encode HTML in link text when

--- a/lib/src/block_parser.dart
+++ b/lib/src/block_parser.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:charcode/charcode.dart';
-
 import 'ast.dart';
 import 'document.dart';
 import 'util.dart';

--- a/lib/src/inline_parser.dart
+++ b/lib/src/inline_parser.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:charcode/charcode.dart';
-
 import 'ast.dart';
 import 'document.dart';
 import 'emojis.dart';

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -1,7 +1,5 @@
 import 'dart:convert';
 
-import 'package:charcode/charcode.dart';
-
 String escapeHtml(String html) =>
     const HtmlEscape(HtmlEscapeMode.element).convert(html);
 
@@ -72,3 +70,120 @@ String escapeAttribute(String value) {
   }
   return result.toString();
 }
+
+/// Character '\'.
+const int $backslash = 0x5C;
+
+/// Character '"'.
+const int $quote = 0x22;
+
+/// Character '!'.
+const int $exclamation = 0x21;
+
+/// Character '#'.
+const int $hash = 0x23;
+
+/// Character '$'.
+const int $dollar = 0x24;
+
+/// Character '%'.
+const int $percent = 0x25;
+
+/// Character '&'.
+const int $ampersand = 0x26;
+
+/// Character '''.
+const int $apostrophe = 0x27;
+
+/// Character '('.
+const int $lparen = 0x28;
+
+/// Character ')'.
+const int $rparen = 0x29;
+
+/// Character '*'.
+const int $asterisk = 0x2A;
+
+/// Character '+'.
+const int $plus = 0x2B;
+
+/// Character ','.
+const int $comma = 0x2C;
+
+/// Character '-'.
+const int $dash = 0x2D;
+
+/// Character '.'.
+const int $dot = 0x2E;
+
+/// Character '/'.
+const int $slash = 0x2F;
+
+/// Character ':'.
+const int $colon = 0x3A;
+
+/// Character ';'.
+const int $semicolon = 0x3B;
+
+/// Character '<'.
+const int $lt = 0x3C;
+
+/// Character '='.
+const int $equal = 0x3D;
+
+/// Character '>'.
+const int $gt = 0x3E;
+
+/// Character '?'.
+const int $question = 0x3F;
+
+/// Character '@'.
+const int $at = 0x40;
+
+/// Character '['.
+const int $lbracket = 0x5B;
+
+/// Character ']'.
+const int $rbracket = 0x5D;
+
+/// Character '^'.
+const int $caret = 0x5E;
+
+/// Character '_'.
+const int $underscore = 0x5F;
+
+/// Character '`'.
+const int $backquote = 0x60;
+
+/// Character '{'.
+const int $lbrace = 0x7B;
+
+/// Character '|'.
+const int $bar = 0x7C;
+
+/// Character '}'.
+const int $rbrace = 0x7D;
+
+/// Character '~'.
+const int $tilde = 0x7E;
+
+/// Space character.
+const int $space = 0x20;
+
+/// Character '"'.
+const int $double_quote = 0x22;
+
+/// "Line feed" control character.
+const int $lf = 0x0A;
+
+/// "Carriage return" control character.
+const int $cr = 0x0D;
+
+/// "Form feed" control character.
+const int $ff = 0x0C;
+
+/// "Horizontal Tab" control character, common name.
+const int $tab = 0x09;
+
+/// "Vertical Tab" control character.
+const int $vt = 0x0B;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,8 +2,7 @@ name: markdown
 version: 2.1.4-dev
 
 description: A library for converting markdown to HTML.
-author: Dart Team <misc@dartlang.org>
-homepage: https://github.com/dart-lang/markdown
+repository: https://github.com/dart-lang/markdown
 
 executables:
   markdown:
@@ -13,7 +12,6 @@ environment:
 
 dependencies:
   args: ^1.0.0
-  charcode: ^1.1.0
 
 dev_dependencies:
   build_runner: ^1.0.0


### PR DESCRIPTION
Inline all used character constants into `util.dart`.

Update pubspec to modern conventions - drop the author field and change
the homepage to repository.