### PR TITLE
This PR illustrates the simple changes needed to the example code to support Mermaid Diagrams. Resolves #228

### DIFF
--- a/example/app.dart
+++ b/example/app.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:html';
 import 'package:markdown/markdown.dart' as md;
-
+import 'package:mermaid/mermaid.dart';
 import 'highlight.dart';
 
 final markdownInput = querySelector('#markdown') as TextAreaElement;
@@ -33,6 +33,17 @@ final extensionSets = {
 };
 
 void main() {
+    MermaidApi.initialize(Config(
+    securityLevel: SecurityLevel.Strict,
+    theme: Theme.Forest,
+    logLevel: LogLevel.Error,
+    startOnLoad: false,
+    arrowMarkerAbsolute: true,
+    flowchart: FlowChartConfig(htmlLabels: true),
+    sequence: SequenceDiagramConfig(),
+    gnatt: GnattConfig(),
+  ));
+
   versionSpan.text = 'v${md.version}';
   markdownInput.onKeyUp.listen(_renderMarkdown);
 
@@ -75,6 +86,9 @@ void _renderMarkdown([Event? event]) {
       window.console.error(e);
     }
   }
+
+  // render mermaid diagrams
+  mermaidRender('code.language-mermaid');
 
   if (event != null) {
     // Not simulated typing. Store it.

--- a/example/index.html
+++ b/example/index.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.0.1/styles/default.min.css">
     <script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.0.1/highlight.min.js"></script>
     <script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.0.1/languages/dart.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
     <script defer src="app.dart.js"></script>
     <title>Dart Markdown Live Editor</title>
   </head>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ environment:
 dependencies:
   args: ^2.0.0
   meta: ^1.3.0
+  mermaid: ^0.9.2
 
 dev_dependencies:
   build_runner: ^2.0.5


### PR DESCRIPTION
This PR illustrates the changes need to the example code to use the mermaid.dart package (interop wrapper for mermaid.js).
This package resolves #228 , in so much as it implements support for Mermaid as @srawlins mentions in his last comment.

[Here is an example illustrating a number of Mermaid diagram types](https://timmaffett.github.io/markdown_mermaid/)

(I also wrote the [mermaid.dart package](https://pub.dev/packages/mermaid) to interop wrap the mermaid.js library. [Github repo](https://github.com/timmaffett/mermaid.dart))

Mermaid is very fast to render and you can edit the chart source in real time and see the rendering.

One unfortunate thing I learned about the mermaid js package while creating this is that it requires the browser DOM to create the SVG files, so server side use of the mermaid.dart package is not possible. (There is a mermaid-cli project that creates a command line version of mermaid using puppeteer some server side solution could be made invoking that from dart).
 
Other than that I was very impressed with the mermaid.js diagram support.

I don't know if this PR has a place in markdown proper, but I wanted to submit it to illustrate how simple the code was to support mermaid diagrams in conjunction with markdown.
