### PR TITLE
Require Dart 2.17, cleanup up lints

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -47,7 +47,7 @@ jobs:
       matrix:
         # Add macos-latest and/or windows-latest if relevant for this package.
         os: [ubuntu-latest]
-        sdk: [2.12.0, dev]
+        sdk: [2.17.0, dev]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 6.0.0-dev
 
+* Require Dart 2.17
 * Add support to GFM extension for GitHub task lists (aka checkboxes).  These
   are only active in the `gitHubFlavored` and `gitHubWeb` extension sets.
 * Add support for `#ff0000` color swatches.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -15,24 +15,15 @@ analyzer:
     unsafe_html: ignore
 linter:
   rules:
-    - camel_case_types
     # https://github.com/dart-lang/linter/issues/574
     #- comment_references
-    - control_flow_in_finally
     - directives_ordering
-    - empty_statements
-    - hash_and_equals
-    - implementation_imports
-    - iterable_contains_unrelated_type
-    - list_remove_unrelated_type
-    - non_constant_identifier_names
     - only_throw_errors
-    - overridden_fields
     - package_api_docs
     - test_types_in_equals
     - throw_in_finally
     - prefer_final_locals
     - use_if_null_to_convert_nulls_to_bools
     - use_raw_strings
+    - use_super_parameters
     - unnecessary_raw_strings
-    - prefer_interpolation_to_compose_strings

--- a/lib/src/inline_syntaxes/delimiter_syntax.dart
+++ b/lib/src/inline_syntaxes/delimiter_syntax.dart
@@ -29,12 +29,12 @@ class DelimiterSyntax extends InlineSyntax {
   /// emphasis delimiters.  If [startCharacter] is passed, it is used as a
   /// pre-matching check which is faster than matching against [pattern].
   DelimiterSyntax(
-    String pattern, {
+    super.pattern, {
     this.requiresDelimiterRun = false,
-    int? startCharacter,
+    super.startCharacter,
     this.allowIntraWord = false,
     this.tags,
-  }) : super(pattern, startCharacter: startCharacter);
+  });
 
   @override
   bool onMatch(InlineParser parser, Match match) {

--- a/lib/src/inline_syntaxes/image_syntax.dart
+++ b/lib/src/inline_syntaxes/image_syntax.dart
@@ -10,9 +10,8 @@ import 'link_syntax.dart';
 /// Matches images like `![alternate text](url "optional title")` and
 /// `![alternate text][label]`.
 class ImageSyntax extends LinkSyntax {
-  ImageSyntax({Resolver? linkResolver})
+  ImageSyntax({super.linkResolver})
       : super(
-          linkResolver: linkResolver,
           pattern: r'!\[',
           startCharacter: $exclamation,
         );

--- a/lib/src/inline_syntaxes/tag_syntax.dart
+++ b/lib/src/inline_syntaxes/tag_syntax.dart
@@ -6,6 +6,5 @@ import 'delimiter_syntax.dart';
 
 @Deprecated('Use DelimiterSyntax instead')
 class TagSyntax extends DelimiterSyntax {
-  TagSyntax(String pattern, {bool requiresDelimiterRun = false})
-      : super(pattern, requiresDelimiterRun: requiresDelimiterRun);
+  TagSyntax(super.pattern, {super.requiresDelimiterRun});
 }

--- a/lib/src/inline_syntaxes/text_syntax.dart
+++ b/lib/src/inline_syntaxes/text_syntax.dart
@@ -16,9 +16,8 @@ class TextSyntax extends InlineSyntax {
   /// If [sub] is passed, it is used as a simple replacement for [pattern]. If
   /// [startCharacter] is passed, it is used as a pre-matching check which is
   /// faster than matching against [pattern].
-  TextSyntax(String pattern, {String sub = '', int? startCharacter})
-      : substitute = sub,
-        super(pattern, startCharacter: startCharacter);
+  TextSyntax(super.pattern, {String sub = '', super.startCharacter})
+      : substitute = sub;
 
   /// Adds a [Text] node to [parser] and returns `true` if there is a
   /// [substitute], as long as the preceding character (if any) is not a `/`.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ executables:
   markdown:
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
   args: ^2.0.0
@@ -23,7 +23,7 @@ dev_dependencies:
   html: ^0.15.0
   io: ^1.0.0
   js: ^0.6.3
-  lints: ^1.0.1
+  lints: ^2.0.0
   path: ^1.8.0
   test: ^1.16.0
   yaml: ^3.0.0


### PR DESCRIPTION
Update pkg:lints to 2.0.0 - remove redundant lints
Added and fixed use_super_parameters
