### PR TITLE
Wrote some crashtest for running against markdown files from pub.dev

### DIFF
--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -1,0 +1,6 @@
+tags:
+  crashtest:
+    skip: 'Only run crashtest tests manually with `dart test -P crashtest`'
+    presets:
+      crashtest:
+        skip: false # Don't skip when running in -P crashtest

--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -1,6 +1,6 @@
 tags:
-  crashtest:
-    skip: 'Only run crashtest tests manually with `dart test -P crashtest`'
+  crash_test:
+    skip: 'Only run crash_test tests manually with `dart test -P crash_test`'
     presets:
-      crashtest:
-        skip: false # Don't skip when running in -P crashtest
+      crash_test:
+        skip: false # Don't skip when running in -P crash_test

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,9 +21,12 @@ dev_dependencies:
   build_web_compilers: ^3.0.0
   collection: ^1.15.0
   html: ^0.15.0
+  http: ^0.13.5
   io: ^1.0.0
   js: ^0.6.3
   lints: ^2.0.0
   path: ^1.8.0
+  pool: ^1.5.1
+  tar: ^0.5.5+1
   test: ^1.16.0
   yaml: ^3.0.0

--- a/test/crash_test.dart
+++ b/test/crash_test.dart
@@ -1,0 +1,122 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:http/http.dart' as http;
+import 'package:http/retry.dart' as http;
+import 'package:markdown/markdown.dart';
+import 'package:pool/pool.dart';
+import 'package:tar/tar.dart';
+import 'package:test/test.dart';
+
+void main() async {
+  // This test is a really dumb and very slow crash-test.
+  // It downloads the latest package version for each package on pub.dev
+  // and tries to parse all `*.md` files in the package, counting the number
+  // of times where the parser throws.
+  //
+  // Needless to say, this test is very slow and running it eats a lot of CPU.
+  // But it's a fairly good way to try a lot of real-world markdown text to see
+  // if any of the poorly formatted markdown causes the parser to crash.
+  test(
+    'crash test',
+    () async {
+      final c = http.RetryClient(http.Client());
+      Future<dynamic> _getJson(String url) async {
+        final u = Uri.tryParse(url);
+        if (u == null) {
+          return null;
+        }
+        try {
+          final data = await c.read(u);
+          try {
+            return jsonDecode(data);
+          } on FormatException {
+            return null;
+          }
+        } on http.ClientException {
+          return null;
+        } on IOException {
+          return null;
+        }
+      }
+
+      final packages =
+          ((await _getJson('https://pub.dev/api/package-names'))['packages']
+                  as List)
+              .cast<String>();
+      print('Found ${packages.length} packages to scan');
+
+      final errors = <String>[];
+      final pool = Pool(50);
+      var count = 0;
+      var skipped = 0;
+      var lastStatus = DateTime.now();
+      await Future.wait(packages.map((package) async {
+        await pool.withResource(() async {
+          final versionsResponse =
+              await _getJson('https://pub.dev/api/packages/$package');
+          final archiveUrl = Uri.tryParse(
+            versionsResponse['latest']?['archive_url'] as String? ?? '',
+          );
+          if (archiveUrl == null) {
+            skipped++;
+            return;
+          }
+          late List<int> archive;
+          try {
+            archive = gzip.decode(await c.readBytes(archiveUrl));
+          } on http.ClientException {
+            skipped++;
+            return;
+          } on IOException {
+            skipped++;
+            return;
+          }
+          try {
+            await TarReader.forEach(Stream.value(archive), (entry) async {
+              if (entry.name.endsWith('.md')) {
+                late String str;
+                try {
+                  final bytes = await http.ByteStream(entry.contents).toBytes();
+                  str = utf8.decode(bytes);
+                } on FormatException {
+                  return; // ignore invalid utf8
+                }
+                try {
+                  markdownToHtml(str, extensionSet: ExtensionSet.gitHubWeb);
+                } catch (err, st) {
+                  errors
+                      .add('package:$package/${entry.name}, throws: $err\n$st');
+                }
+              }
+            });
+          } on FormatException {
+            skipped++;
+            return;
+          }
+        });
+        count++;
+        if (DateTime.now().difference(lastStatus) > Duration(seconds: 30)) {
+          lastStatus = DateTime.now();
+          print('Scanned $count / ${packages.length} (skipped $skipped),'
+              ' found ${errors.length} issues');
+        }
+      }));
+
+      await pool.close();
+      c.close();
+
+      if (errors.isNotEmpty) {
+        print('Found issues:');
+        errors.forEach(print);
+        fail('Found ${errors.length} cases where markdownToHtml threw!');
+      }
+    },
+    timeout: Timeout(Duration(hours: 1)),
+    tags: 'crashtest', // skipped by default, see: dart_test.yaml
+  );
+}

--- a/test/crash_test.dart
+++ b/test/crash_test.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
@@ -79,15 +79,18 @@ void main() async {
           try {
             await TarReader.forEach(Stream.value(archive), (entry) async {
               if (entry.name.endsWith('.md')) {
-                late String str;
+                late String contents;
                 try {
                   final bytes = await http.ByteStream(entry.contents).toBytes();
-                  str = utf8.decode(bytes);
+                  contents = utf8.decode(bytes);
                 } on FormatException {
                   return; // ignore invalid utf8
                 }
                 try {
-                  markdownToHtml(str, extensionSet: ExtensionSet.gitHubWeb);
+                  markdownToHtml(
+                    contents,
+                    extensionSet: ExtensionSet.gitHubWeb,
+                  );
                 } catch (err, st) {
                   errors
                       .add('package:$package/${entry.name}, throws: $err\n$st');
@@ -117,6 +120,6 @@ void main() async {
       }
     },
     timeout: Timeout(Duration(hours: 1)),
-    tags: 'crashtest', // skipped by default, see: dart_test.yaml
+    tags: 'crash_test', // skipped by default, see: dart_test.yaml
   );
 }

--- a/test/crash_test.dart
+++ b/test/crash_test.dart
@@ -12,6 +12,8 @@ import 'package:pool/pool.dart';
 import 'package:tar/tar.dart';
 import 'package:test/test.dart';
 
+// ignore_for_file: avoid_dynamic_calls
+
 void main() async {
   // This test is a really dumb and very slow crash-test.
   // It downloads the latest package version for each package on pub.dev
@@ -103,7 +105,8 @@ void main() async {
           }
         });
         count++;
-        if (DateTime.now().difference(lastStatus) > Duration(seconds: 30)) {
+        if (DateTime.now().difference(lastStatus) >
+            const Duration(seconds: 30)) {
           lastStatus = DateTime.now();
           print('Scanned $count / ${packages.length} (skipped $skipped),'
               ' found ${errors.length} issues');
@@ -119,7 +122,7 @@ void main() async {
         fail('Found ${errors.length} cases where markdownToHtml threw!');
       }
     },
-    timeout: Timeout(Duration(hours: 1)),
+    timeout: const Timeout(Duration(hours: 1)),
     tags: 'crash_test', // skipped by default, see: dart_test.yaml
   );
 }

--- a/test/crash_test.dart
+++ b/test/crash_test.dart
@@ -25,7 +25,7 @@ void main() async {
     'crash test',
     () async {
       final c = http.RetryClient(http.Client());
-      Future<dynamic> _getJson(String url) async {
+      Future<dynamic> getJson(String url) async {
         final u = Uri.tryParse(url);
         if (u == null) {
           return null;
@@ -45,7 +45,7 @@ void main() async {
       }
 
       final packages =
-          ((await _getJson('https://pub.dev/api/package-names'))['packages']
+          ((await getJson('https://pub.dev/api/package-names'))['packages']
                   as List)
               .cast<String>();
       print('Found ${packages.length} packages to scan');
@@ -58,7 +58,7 @@ void main() async {
       await Future.wait(packages.map((package) async {
         await pool.withResource(() async {
           final versionsResponse =
-              await _getJson('https://pub.dev/api/packages/$package');
+              await getJson('https://pub.dev/api/packages/$package');
           final archiveUrl = Uri.tryParse(
             versionsResponse['latest']?['archive_url'] as String? ?? '',
           );


### PR DESCRIPTION
This might be total overkill :rofl: 

I found 26 cases where it crashed all instances of https://github.com/dart-lang/markdown/issues/445.

It took about 20 minutes to run the tests on my desktop. I'm not sure it's worthwhile merging / keeping it around.
But it could be useful to run once in a while, because there should be no text input that causes the markdown parser to throw.