### PR TITLE
Add an `enableTagfilter` option to `HtmlRenderer` to eanble GFM `tagfilter` extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 * **Breaking change**: Removed `BlockHtmlSyntax`, `BlockTagBlockHtmlSyntax`,
   `LongBlockHtmlSyntax`, and `OtherTagBlockHtmlSyntax`.
 * Add a new syntax `HtmlBlockSyntax` to parse HTML blocks.
+* Add an `enableTagfilter` option to `HtmlRenderer` to eanble GFM `tagfilter`
+  extension.
 * Add a new syntax `DecodeHtmlSyntax` to decode HTML entity and numeric
   character references.
 * Add a new syntax `SoftLineBreakSyntax` to remove the single space before the

--- a/lib/src/html_renderer.dart
+++ b/lib/src/html_renderer.dart
@@ -20,6 +20,7 @@ String markdownToHtml(
   Resolver? imageLinkResolver,
   bool inlineOnly = false,
   bool encodeHtml = true,
+  bool enableTagfilter = false,
   bool withDefaultBlockSyntaxes = true,
   bool withDefaultInlineSyntaxes = true,
 }) {
@@ -41,11 +42,14 @@ String markdownToHtml(
 
   final nodes = document.parseLines(lines);
 
-  return '${renderToHtml(nodes)}\n';
+  return '${renderToHtml(nodes, enableTagfilter: enableTagfilter)}\n';
 }
 
 /// Renders [nodes] to HTML.
-String renderToHtml(List<Node> nodes) => HtmlRenderer().render(nodes);
+String renderToHtml(List<Node> nodes, {bool enableTagfilter = false}) =>
+    HtmlRenderer(
+      enableTagfilter: enableTagfilter,
+    ).render(nodes);
 
 const _blockTags = [
   'blockquote',
@@ -92,8 +96,11 @@ class HtmlRenderer implements NodeVisitor {
 
   final _elementStack = <Element>[];
   String? _lastVisitedTag;
+  final bool _tagfilterEnabled;
 
-  HtmlRenderer();
+  HtmlRenderer({
+    bool enableTagfilter = false,
+  }) : _tagfilterEnabled = enableTagfilter;
 
   String render(List<Node> nodes) {
     buffer = StringBuffer();
@@ -109,6 +116,10 @@ class HtmlRenderer implements NodeVisitor {
   @override
   void visitText(Text text) {
     var content = text.textContent;
+
+    if (_tagfilterEnabled) {
+      content = _filterTags(content);
+    }
     if (const ['br', 'p', 'li'].contains(_lastVisitedTag)) {
       final lines = LineSplitter.split(content);
       content = content.contains('<pre>')
@@ -193,4 +204,18 @@ class HtmlRenderer implements NodeVisitor {
     uniqueIds.add(suffixedId);
     return suffixedId;
   }
+
+  /// Filters some particular tags, see:
+  /// https://github.github.com/gfm/#disallowed-raw-html-extension-
+  // As said in the specification, this process should happen when rendering
+  // HTML output, so there should not be a dedicated syntax for this extension.
+  String _filterTags(String content) => content.replaceAll(
+      RegExp(
+        '<(?=(?:'
+        'title|textarea|style|xmp|iframe|noembed|noframes|script|plaintext'
+        ')>)',
+        caseSensitive: false,
+        multiLine: true,
+      ),
+      '&lt;');
 }

--- a/test/gfm/disallowed_raw_html_extension.unit
+++ b/test/gfm/disallowed_raw_html_extension.unit
@@ -5,6 +5,6 @@
   <xmp> is disallowed.  <XMP> is also disallowed.
 </blockquote>
 <<<
-<p><strong> <title> <style> <em></p><blockquote>
-<xmp> is disallowed.  <XMP> is also disallowed.
+<p><strong> &lt;title> &lt;style> <em></p><blockquote>
+&lt;xmp> is disallowed.  &lt;XMP> is also disallowed.
 </blockquote>

--- a/test/util.dart
+++ b/test/util.dart
@@ -17,6 +17,7 @@ void testDirectory(String name, {ExtensionSet? extensionSet}) {
 
     final inlineSyntaxes = <InlineSyntax>[];
     final blockSyntaxes = <BlockSyntax>[];
+    var enableTagfilter = false;
 
     if (dataCase.file.endsWith('_extension')) {
       final extension = dataCase.file.substring(
@@ -34,7 +35,7 @@ void testDirectory(String name, {ExtensionSet? extensionSet}) {
           blockSyntaxes.add(const TableSyntax());
           break;
         case 'disallowed_raw_html':
-          // TODO(Zhiguang): https://github.com/dart-lang/markdown/pull/447
+          enableTagfilter = true;
           break;
         default:
           throw UnimplementedError('Unimplemented extension "$extension"');
@@ -48,6 +49,7 @@ void testDirectory(String name, {ExtensionSet? extensionSet}) {
       extensionSet: extensionSet,
       inlineSyntaxes: inlineSyntaxes,
       blockSyntaxes: blockSyntaxes,
+      enableTagfilter: enableTagfilter,
     );
   }
 }
@@ -81,6 +83,7 @@ void validateCore(
   Resolver? linkResolver,
   Resolver? imageLinkResolver,
   bool inlineOnly = false,
+  bool enableTagfilter = false,
 }) {
   test(description, () {
     final result = markdownToHtml(
@@ -91,6 +94,7 @@ void validateCore(
       linkResolver: linkResolver,
       imageLinkResolver: imageLinkResolver,
       inlineOnly: inlineOnly,
+      enableTagfilter: enableTagfilter,
     );
 
     markdownPrintOnFailure(markdown, html, result);

--- a/tool/stats_lib.dart
+++ b/tool/stats_lib.dart
@@ -128,13 +128,7 @@ CompareResult compareResult(
   bool verboseLooseMatch = false,
   Set<String> extensions = const {},
 }) {
-  var enableTagfilter = false;
-
-  for (final extension in testCase.extensions ?? []) {
-    if (extension == 'tagfilter') {
-      enableTagfilter = true;
-    }
-  }
+  var enabletagfilter = false;
 
   String output;
   final inlineSyntaxes = <InlineSyntax>[];
@@ -152,7 +146,7 @@ CompareResult compareResult(
         blockSyntaxes.add(const TableSyntax());
         break;
       case 'tagfilter':
-        // TODO(Zhiguang): https://github.com/dart-lang/markdown/pull/447
+        enabletagfilter = true;
         break;
       default:
         throw UnimplementedError('Unimplemented extension "$extension"');
@@ -164,6 +158,7 @@ CompareResult compareResult(
       testCase.markdown,
       inlineSyntaxes: inlineSyntaxes,
       blockSyntaxes: blockSyntaxes,
+      enableTagfilter: enabletagfilter,
     );
   } catch (err, stackTrace) {
     if (throwOnError) {

--- a/tool/stats_lib.dart
+++ b/tool/stats_lib.dart
@@ -128,6 +128,14 @@ CompareResult compareResult(
   bool verboseLooseMatch = false,
   Set<String> extensions = const {},
 }) {
+  var enableTagfilter = false;
+
+  for (final extension in testCase.extensions ?? []) {
+    if (extension == 'tagfilter') {
+      enableTagfilter = true;
+    }
+  }
+
   String output;
   final inlineSyntaxes = <InlineSyntax>[];
   final blockSyntaxes = <BlockSyntax>[];


### PR DESCRIPTION
This is a GFM extension, see: https://github.github.com/gfm/#disallowed-raw-html-extension-

But it still fails the test case. it is because of another issue.