### PR TITLE
Add deprecated accessors for indicatorForUncheckedCheckBox and indicatorForCheckedCheckBox

### DIFF
--- a/lib/src/block_syntaxes/list_syntax.dart
+++ b/lib/src/block_syntaxes/list_syntax.dart
@@ -10,8 +10,13 @@ import 'ordered_list_with_checkbox_syntax.dart';
 import 'unordered_list_with_checkbox_syntax.dart';
 
 
+/// As of Markdown 6.0.1 invisible indicators for checked/unchecked checkboxes are
+/// no longer used.  These constants are now empty strings to reflect that.
 @Deprecated('This string is no longer used internally.  It will be removed in a future version.')
 const indicatorForUncheckedCheckBox = '';
+
+/// As of Markdown 6.0.1 invisible indicators for checked/unchecked checkboxes are
+/// no longer used.  These constants are now empty strings to reflect that.
 @Deprecated('This string is no longer used internally.  It be will be removed in a future version.')
 const indicatorForCheckedCheckBox = '';
 

--- a/lib/src/block_syntaxes/list_syntax.dart
+++ b/lib/src/block_syntaxes/list_syntax.dart
@@ -11,9 +11,9 @@ import 'unordered_list_with_checkbox_syntax.dart';
 
 
 @Deprecated('This string is no longer used internally.  It will be removed in a future version.')
-const indicatorForUncheckedCheckBox = 'd';
+const indicatorForUncheckedCheckBox = '';
 @Deprecated('This string is no longer used internally.  It be will be removed in a future version.')
-const indicatorForCheckedCheckBox = 'd';
+const indicatorForCheckedCheckBox = '';
 
 class ListItem {
   const ListItem(

--- a/lib/src/block_syntaxes/list_syntax.dart
+++ b/lib/src/block_syntaxes/list_syntax.dart
@@ -9,6 +9,12 @@ import 'block_syntax.dart';
 import 'ordered_list_with_checkbox_syntax.dart';
 import 'unordered_list_with_checkbox_syntax.dart';
 
+
+@Deprecated('This string is no longer used internally.  It will be removed in a future version.')
+const indicatorForUncheckedCheckBox = 'd';
+@Deprecated('This string is no longer used internally.  It be will be removed in a future version.')
+const indicatorForCheckedCheckBox = 'd';
+
 class ListItem {
   const ListItem(
     this.lines, {

--- a/lib/src/block_syntaxes/list_syntax.dart
+++ b/lib/src/block_syntaxes/list_syntax.dart
@@ -9,15 +9,16 @@ import 'block_syntax.dart';
 import 'ordered_list_with_checkbox_syntax.dart';
 import 'unordered_list_with_checkbox_syntax.dart';
 
-
 /// As of Markdown 6.0.1 invisible indicators for checked/unchecked checkboxes are
 /// no longer used.  These constants are now empty strings to reflect that.
-@Deprecated('This string is no longer used internally.  It will be removed in a future version.')
+@Deprecated(
+    'This string is no longer used internally.  It will be removed in a future version.')
 const indicatorForUncheckedCheckBox = '';
 
 /// As of Markdown 6.0.1 invisible indicators for checked/unchecked checkboxes are
 /// no longer used.  These constants are now empty strings to reflect that.
-@Deprecated('This string is no longer used internally.  It be will be removed in a future version.')
+@Deprecated(
+    'This string is no longer used internally.  It be will be removed in a future version.')
 const indicatorForCheckedCheckBox = '';
 
 class ListItem {


### PR DESCRIPTION
This PR adds back in the obsolete/removed `indicatorForUncheckedCheckBox` and `indicatorForCheckedCheckBox` symbols.
They have been  marked deprecated and changed to *empty strings* to reflect that the previous invisible non-breaking space containing symbols are not used internally to trigger checkboxes, so they will not be found in the output of markdown.

I would love any suggestions for better deprecated messages for these two, as well as any other suggestions.

Please see detailed discussion at https://github.com/dart-lang/markdown/pull/450  .

By now returning empty strings this should allow any test code using these symbols to predict the expected output of checkbox markup to continue to work unchanged with the new checkbox scheme that does not any invisible non-breaking space symbols.

This change alone allows the current version of `flutter_markdown` to compile correctly and for all tests to compile and pass.

(I have an additional pr for flutter_markdown that completely removes their use, but this is for any other users of these symbols. I would expect that any use of these would have been for testing similar to how flutter_markdown used them, and this change prevent the new checkbox scheme from being a braking change.)