### PR TITLE
Use fewer empty lists; non-growable

### DIFF
--- a/lib/src/ast.dart
+++ b/lib/src/ast.dart
@@ -21,7 +21,7 @@ class Element implements Node {
   String? generatedId;
 
   /// Instantiates a [tag] Element with [children].
-  Element(this.tag, this.children) : attributes = <String, String>{};
+  Element(this.tag, this.children) : attributes = {};
 
   /// Instantiates an empty, self-closing [tag] Element.
   Element.empty(this.tag)
@@ -30,7 +30,7 @@ class Element implements Node {
 
   /// Instantiates a [tag] Element with no [children].
   Element.withTag(this.tag)
-      : children = [],
+      : children = const [],
         attributes = {};
 
   /// Instantiates a [tag] Element with a single Text child.
@@ -55,7 +55,10 @@ class Element implements Node {
 
   @override
   String get textContent {
-    return (children ?? []).map((child) => child.textContent).join('');
+    final children = this.children;
+    return children == null
+        ? ''
+        : children.map((child) => child.textContent).join('');
   }
 }
 

--- a/lib/src/block_syntaxes/table_syntax.dart
+++ b/lib/src/block_syntaxes/table_syntax.dart
@@ -93,7 +93,7 @@ class TableSyntax extends BlockSyntax {
       if (column.startsWith(':')) return 'left';
       if (column.endsWith(':')) return 'right';
       return null;
-    }).toList();
+    }).toList(growable: false);
   }
 
   /// Parses a table row at the current line into a table row element, with

--- a/lib/src/document.dart
+++ b/lib/src/document.dart
@@ -11,7 +11,7 @@ import 'inline_syntaxes/inline_syntax.dart';
 
 /// Maintains the context needed to parse a Markdown document.
 class Document {
-  final Map<String, LinkReference> linkReferences = <String, LinkReference>{};
+  final Map<String, LinkReference> linkReferences = {};
   final Resolver? linkResolver;
   final Resolver? imageLinkResolver;
   final bool encodeHtml;
@@ -44,8 +44,12 @@ class Document {
     this.withDefaultInlineSyntaxes = true,
   }) : hasCustomInlineSyntaxes = (inlineSyntaxes?.isNotEmpty ?? false) ||
             (extensionSet?.inlineSyntaxes.isNotEmpty ?? false) {
-    _blockSyntaxes.addAll(blockSyntaxes ?? []);
-    _inlineSyntaxes.addAll(inlineSyntaxes ?? []);
+    if (blockSyntaxes != null) {
+      _blockSyntaxes.addAll(blockSyntaxes);
+    }
+    if (inlineSyntaxes != null) {
+      _inlineSyntaxes.addAll(inlineSyntaxes);
+    }
 
     if (extensionSet == null) {
       if (withDefaultBlockSyntaxes) {

--- a/lib/src/extension_set.dart
+++ b/lib/src/extension_set.dart
@@ -27,10 +27,7 @@ class ExtensionSet {
   /// fenced code blocks, or inline HTML.
   ///
   /// [Markdown.pl]: http://daringfireball.net/projects/markdown/syntax
-  static final ExtensionSet none = ExtensionSet(
-    List<BlockSyntax>.unmodifiable(<BlockSyntax>[]),
-    List<InlineSyntax>.unmodifiable(<InlineSyntax>[]),
-  );
+  static final ExtensionSet none = ExtensionSet(const [], const []);
 
   /// The [commonMark] extension set is close to compliance with [CommonMark].
   ///

--- a/lib/src/inline_syntaxes/delimiter_syntax.dart
+++ b/lib/src/inline_syntaxes/delimiter_syntax.dart
@@ -63,7 +63,7 @@ class DelimiterSyntax extends InlineSyntax {
       syntax: this,
       node: text,
       allowIntraWord: allowIntraWord,
-      tags: tags ?? [],
+      tags: tags ?? const [],
     );
     if (delimiterRun != null) {
       parser.pushDelimiter(delimiterRun);


### PR DESCRIPTION
Mainly this replaces a few `foo ?? []` cases with something that does not unnecessarily create a new list. Maybe simpler readability too.