### PR TITLE
Add `startCharacter` to some delimiter syntaxes

### DIFF
--- a/lib/src/inline_syntaxes/emphasis_syntax.dart
+++ b/lib/src/inline_syntaxes/emphasis_syntax.dart
@@ -2,12 +2,18 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import '../charcode.dart';
 import 'delimiter_syntax.dart';
 
 class EmphasisSyntax extends DelimiterSyntax {
   /// Parses `__strong__` and `_emphasis_`.
   EmphasisSyntax.underscore()
-      : super('_+', requiresDelimiterRun: true, tags: _tags);
+      : super(
+          '_+',
+          requiresDelimiterRun: true,
+          tags: _tags,
+          startCharacter: $underscore,
+        );
 
   /// Parses `**strong**` and `*emphasis*`.
   EmphasisSyntax.asterisk()
@@ -16,6 +22,7 @@ class EmphasisSyntax extends DelimiterSyntax {
           requiresDelimiterRun: true,
           allowIntraWord: true,
           tags: _tags,
+          startCharacter: $asterisk,
         );
 
   static final _tags = [DelimiterTag('em', 1), DelimiterTag('strong', 2)];

--- a/lib/src/inline_syntaxes/strikethrough_syntax.dart
+++ b/lib/src/inline_syntaxes/strikethrough_syntax.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import '../charcode.dart';
 import 'delimiter_syntax.dart';
 
 /// Matches strikethrough syntax according to the GFM spec.
@@ -11,6 +12,7 @@ class StrikethroughSyntax extends DelimiterSyntax {
           '~+',
           requiresDelimiterRun: true,
           allowIntraWord: true,
+          startCharacter: $tilde,
           tags: [DelimiterTag('del', 2)],
         );
 }


### PR DESCRIPTION
I forgot to add them when I created these syntaxes.

## benchmark before
![Screenshot 2022-11-09 at 04 48 49](https://user-images.githubusercontent.com/5637609/200734588-ed66866a-b267-4f6c-9f07-5ba6dffce437.png)

## benchmark after

![Screenshot 2022-11-09 at 04 47 58](https://user-images.githubusercontent.com/5637609/200734578-09301009-81f8-444e-bfaa-861f188c646f.png)
