### PR TITLE
Improve ease of use [proposal]

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -15,6 +15,9 @@ analyzer:
     # The example app explicitly takes a String of user-generated HTML and
     # inserts it straight into a <div> using innerHtml.
     unsafe_html: ignore
+
+    # TODO(Zhiguang): remove it when the deprecated Document is deleted.
+    deprecated_member_use_from_same_package: ignore
 linter:
   rules:
     # https://github.com/dart-lang/linter/issues/574

--- a/lib/markdown.dart
+++ b/lib/markdown.dart
@@ -82,5 +82,6 @@ export 'src/inline_syntaxes/link_syntax.dart';
 export 'src/inline_syntaxes/soft_line_break_syntax.dart';
 export 'src/inline_syntaxes/strikethrough_syntax.dart';
 export 'src/inline_syntaxes/text_syntax.dart';
+export 'src/markdown.dart';
 
 const version = packageVersion;

--- a/lib/src/block_parser.dart
+++ b/lib/src/block_parser.dart
@@ -60,7 +60,7 @@ class BlockParser {
   BlockParser(
     this.lines,
     this.document, {
-    @Deprecated('this option will be removed from the next major eversion')
+    @Deprecated('this option will be removed from the next release')
         this.markdown,
   }) {
     if (markdown != null) {

--- a/lib/src/block_parser.dart
+++ b/lib/src/block_parser.dart
@@ -16,6 +16,7 @@ import 'block_syntaxes/paragraph_syntax.dart';
 import 'block_syntaxes/setext_header_syntax.dart';
 import 'block_syntaxes/unordered_list_syntax.dart';
 import 'document.dart';
+import 'markdown.dart';
 
 /// Maintains the internal state needed to parse a series of lines into blocks
 /// of Markdown suitable for further inline parsing.
@@ -23,7 +24,11 @@ class BlockParser {
   final List<String> lines;
 
   /// The Markdown document this parser is parsing.
+  // TODO(Zhiguang): change the type to Markdown.
   final Document document;
+
+  @Deprecated('Use `document` instead')
+  final Markdown? markdown;
 
   /// The enabled block syntaxes.
   ///
@@ -52,13 +57,22 @@ class BlockParser {
     const ParagraphSyntax()
   ];
 
-  BlockParser(this.lines, this.document) {
-    blockSyntaxes.addAll(document.blockSyntaxes);
-
-    if (document.withDefaultBlockSyntaxes) {
-      blockSyntaxes.addAll(standardBlockSyntaxes);
+  BlockParser(
+    this.lines,
+    this.document, {
+    @Deprecated('this option will be removed from the next major eversion')
+        this.markdown,
+  }) {
+    if (markdown != null) {
+      blockSyntaxes.addAll(markdown!.blockSyntaxes);
     } else {
-      blockSyntaxes.add(const DummyBlockSyntax());
+      blockSyntaxes.addAll(document.blockSyntaxes);
+
+      if (document.withDefaultBlockSyntaxes) {
+        blockSyntaxes.addAll(standardBlockSyntaxes);
+      } else {
+        blockSyntaxes.add(const DummyBlockSyntax());
+      }
     }
   }
 

--- a/lib/src/block_syntaxes/block_syntax.dart
+++ b/lib/src/block_syntaxes/block_syntax.dart
@@ -4,8 +4,9 @@
 
 import '../ast.dart';
 import '../block_parser.dart';
+import '../syntax.dart';
 
-abstract class BlockSyntax {
+abstract class BlockSyntax extends Syntax {
   const BlockSyntax();
 
   /// Gets the regex used to identify the beginning of this block, if any.

--- a/lib/src/block_syntaxes/blockquote_syntax.dart
+++ b/lib/src/block_syntaxes/blockquote_syntax.dart
@@ -73,7 +73,11 @@ class BlockquoteSyntax extends BlockSyntax {
     final childLines = parseChildLines(parser);
 
     // Recursively parse the contents of the blockquote.
-    final children = BlockParser(childLines, parser.document).parseLines();
+    final children = BlockParser(
+      childLines,
+      parser.document,
+      markdown: parser.markdown,
+    ).parseLines();
 
     return Element('blockquote', children);
   }

--- a/lib/src/block_syntaxes/code_block_syntax.dart
+++ b/lib/src/block_syntaxes/code_block_syntax.dart
@@ -53,7 +53,9 @@ class CodeBlockSyntax extends BlockSyntax {
     childLines.add('');
 
     var content = childLines.join('\n');
-    if (parser.document.encodeHtml) {
+    if (parser.markdown != null
+        ? parser.markdown!.escapeHtml
+        : parser.document.encodeHtml) {
       content = escapeHtml(content);
     }
 

--- a/lib/src/block_syntaxes/fenced_blockquote_syntax.dart
+++ b/lib/src/block_syntaxes/fenced_blockquote_syntax.dart
@@ -38,7 +38,11 @@ class FencedBlockquoteSyntax extends BlockSyntax {
     final childLines = parseChildLines(parser);
 
     // Recursively parse the contents of the blockquote.
-    final children = BlockParser(childLines, parser.document).parseLines();
+    final children = BlockParser(
+      childLines,
+      parser.document,
+      markdown: parser.markdown,
+    ).parseLines();
     return Element('blockquote', children);
   }
 }

--- a/lib/src/block_syntaxes/fenced_code_block_syntax.dart
+++ b/lib/src/block_syntaxes/fenced_code_block_syntax.dart
@@ -29,7 +29,9 @@ class FencedCodeBlockSyntax extends BlockSyntax {
       openingFence.indent,
     ).join('\n');
 
-    if (parser.document.encodeHtml) {
+    if (parser.markdown != null
+        ? parser.markdown!.escapeHtml
+        : parser.document.encodeHtml) {
       text = escapeHtml(text);
     }
     if (text.isNotEmpty) {
@@ -39,7 +41,9 @@ class FencedCodeBlockSyntax extends BlockSyntax {
     final code = Element.text('code', text);
     if (openingFence.hasLanguage) {
       var language = decodeHtmlCharacters(openingFence.language);
-      if (parser.document.encodeHtml) {
+      if (parser.markdown != null
+          ? parser.markdown!.escapeHtml
+          : parser.document.encodeHtml) {
         language = escapeHtmlAttribute(language);
       }
       code.attributes['class'] = 'language-$language';

--- a/lib/src/block_syntaxes/list_syntax.dart
+++ b/lib/src/block_syntaxes/list_syntax.dart
@@ -193,7 +193,11 @@ abstract class ListSyntax extends BlockSyntax {
         }
       }
 
-      final itemParser = BlockParser(item.lines, parser.document);
+      final itemParser = BlockParser(
+        item.lines,
+        parser.document,
+        markdown: parser.markdown,
+      );
       final children = itemParser.parseLines();
       final itemElement = checkboxToInsert == null
           ? Element('li', children)

--- a/lib/src/block_syntaxes/paragraph_syntax.dart
+++ b/lib/src/block_syntaxes/paragraph_syntax.dart
@@ -174,8 +174,14 @@ class ParagraphSyntax extends BlockSyntax {
     // References are case-insensitive, and internal whitespace is compressed.
     label = normalizeLinkLabel(label);
 
-    parser.document.linkReferences
-        .putIfAbsent(label, () => LinkReference(label, destination, title));
+    final linkReferences = parser.markdown != null
+        ? parser.markdown!.linkReferences
+        : parser.document.linkReferences;
+
+    linkReferences.putIfAbsent(
+      label,
+      () => LinkReference(label, destination, title),
+    );
     return true;
   }
 }

--- a/lib/src/document.dart
+++ b/lib/src/document.dart
@@ -10,6 +10,7 @@ import 'inline_parser.dart';
 import 'inline_syntaxes/inline_syntax.dart';
 
 @Deprecated('Use Markdown instead')
+
 /// Maintains the context needed to parse a Markdown document.
 class Document {
   final Map<String, LinkReference> linkReferences = {};

--- a/lib/src/document.dart
+++ b/lib/src/document.dart
@@ -9,6 +9,7 @@ import 'extension_set.dart';
 import 'inline_parser.dart';
 import 'inline_syntaxes/inline_syntax.dart';
 
+@Deprecated('Use Markdown instead')
 /// Maintains the context needed to parse a Markdown document.
 class Document {
   final Map<String, LinkReference> linkReferences = {};

--- a/lib/src/extension_set.dart
+++ b/lib/src/extension_set.dart
@@ -31,6 +31,7 @@ class ExtensionSet {
   /// The [commonMark] extension set is close to compliance with [CommonMark].
   ///
   /// [CommonMark]: http://commonmark.org/
+  @Deprecated('Use Markdown.commonMark() instead')
   static final ExtensionSet commonMark = ExtensionSet(
     List<BlockSyntax>.unmodifiable(
       <BlockSyntax>[const FencedCodeBlockSyntax()],
@@ -49,6 +50,7 @@ class ExtensionSet {
   /// linkable IDs.)
   ///
   /// [GitHub flavored Markdown]: https://github.github.com/gfm/
+  @Deprecated('Use Markdown.gitHubWeb() instead')
   static final ExtensionSet gitHubWeb = ExtensionSet(
     List<BlockSyntax>.unmodifiable(
       <BlockSyntax>[
@@ -73,6 +75,7 @@ class ExtensionSet {
 
   /// The [gitHubFlavored] extension set is close to compliance with the
   /// [GitHub flavored Markdown spec](https://github.github.com/gfm/).
+  @Deprecated('Use Markdown.gitHubFlavored() instead')
   static final ExtensionSet gitHubFlavored = ExtensionSet(
     List<BlockSyntax>.unmodifiable(
       <BlockSyntax>[

--- a/lib/src/html_renderer.dart
+++ b/lib/src/html_renderer.dart
@@ -11,7 +11,7 @@ import 'extension_set.dart';
 import 'inline_syntaxes/inline_syntax.dart';
 
 /// Converts the given string of Markdown to HTML.
-@Deprecated('Markdown().toHtml() instead')
+@Deprecated('use List<Node>.toHtml() instead')
 String markdownToHtml(
   String markdown, {
   Iterable<BlockSyntax> blockSyntaxes = const [],
@@ -46,7 +46,7 @@ String markdownToHtml(
 }
 
 /// Renders [nodes] to HTML.
-@Deprecated('List<Node>.toHtml() instead')
+@Deprecated('use List<Node>.toHtml() instead')
 String renderToHtml(List<Node> nodes) => HtmlRenderer().render(nodes);
 
 const _blockTags = [
@@ -197,7 +197,7 @@ class HtmlRenderer implements NodeVisitor {
   }
 }
 
-extension NodesToHtmlExtensions on List<Node> {
+extension MarkdownNodesExtensions on List<Node> {
   /// Renders [Node] list to HTML.
-  String toHtml() => HtmlRenderer().render(this);
+  String toHtml() => '${HtmlRenderer().render(this)}\n';
 }

--- a/lib/src/html_renderer.dart
+++ b/lib/src/html_renderer.dart
@@ -11,6 +11,7 @@ import 'extension_set.dart';
 import 'inline_syntaxes/inline_syntax.dart';
 
 /// Converts the given string of Markdown to HTML.
+@Deprecated('Markdown().toHtml() instead')
 String markdownToHtml(
   String markdown, {
   Iterable<BlockSyntax> blockSyntaxes = const [],
@@ -45,6 +46,7 @@ String markdownToHtml(
 }
 
 /// Renders [nodes] to HTML.
+@Deprecated('List<Node>.toHtml() instead')
 String renderToHtml(List<Node> nodes) => HtmlRenderer().render(nodes);
 
 const _blockTags = [
@@ -193,4 +195,9 @@ class HtmlRenderer implements NodeVisitor {
     uniqueIds.add(suffixedId);
     return suffixedId;
   }
+}
+
+extension NodesToHtmlExtensions on List<Node> {
+  /// Renders [Node] list to HTML.
+  String toHtml() => HtmlRenderer().render(this);
 }

--- a/lib/src/inline_parser.dart
+++ b/lib/src/inline_parser.dart
@@ -66,7 +66,7 @@ class InlineParser {
   InlineParser(
     this.source,
     this.document, {
-    @Deprecated('this option will be removed from the next major eversion')
+    @Deprecated('this option will be removed from the next release')
         this.markdown,
   }) {
     if (markdown != null) {

--- a/lib/src/inline_syntaxes/inline_syntax.dart
+++ b/lib/src/inline_syntaxes/inline_syntax.dart
@@ -3,10 +3,11 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import '../inline_parser.dart';
+import '../syntax.dart';
 import '../util.dart';
 
 /// Represents one kind of Markdown tag that can be parsed.
-abstract class InlineSyntax {
+abstract class InlineSyntax extends Syntax {
   final RegExp pattern;
 
   /// The first character of [pattern], to be used as an efficient first check

--- a/lib/src/inline_syntaxes/link_syntax.dart
+++ b/lib/src/inline_syntaxes/link_syntax.dart
@@ -174,7 +174,9 @@ class LinkSyntax extends DelimiterSyntax {
     final getChildren = context.getChildren;
     final link = _resolveReferenceLink(
       label,
-      parser.document.linkReferences,
+      parser.markdown != null
+          ? parser.markdown!.linkReferences
+          : parser.document.linkReferences,
       getChildren: getChildren,
     );
     if (link != null) {

--- a/lib/src/markdown.dart
+++ b/lib/src/markdown.dart
@@ -6,6 +6,7 @@ import 'ast.dart';
 import 'block_syntaxes/block_syntax.dart';
 import 'block_syntaxes/blockquote_syntax.dart';
 import 'block_syntaxes/code_block_syntax.dart';
+import 'block_syntaxes/empty_block_syntax.dart';
 import 'block_syntaxes/fenced_blockquote_syntax.dart';
 import 'block_syntaxes/fenced_code_block_syntax.dart';
 import 'block_syntaxes/header_syntax.dart';
@@ -26,6 +27,8 @@ import 'inline_syntaxes/autolink_extension_syntax.dart';
 import 'inline_syntaxes/autolink_syntax.dart';
 import 'inline_syntaxes/code_syntax.dart';
 import 'inline_syntaxes/color_swatch_syntax.dart';
+import 'inline_syntaxes/decode_html_syntax.dart';
+import 'inline_syntaxes/email_autolink_syntax.dart';
 import 'inline_syntaxes/emoji_syntax.dart';
 import 'inline_syntaxes/emphasis_syntax.dart';
 import 'inline_syntaxes/escape_html_syntax.dart';
@@ -55,6 +58,7 @@ class Markdown {
 
   Markdown({
     bool enableAtxHeading = true,
+    bool enableBlankLine = true,
     bool enableHeadingId = false,
     bool enableBlockquote = true,
     bool enableIndentedCodeBlock = true,
@@ -79,6 +83,7 @@ class Markdown {
     bool enableSoftLineBreak = true,
     bool enableStrikethrough = false,
     bool enableTaskList = false,
+    bool enableDecodeHtml = true,
     Resolver? linkResolver,
     Resolver? imageLinkResolver,
     Iterable<Syntax> extensions = const [],
@@ -93,6 +98,7 @@ class Markdown {
     }
 
     _blockSyntaxes.addAll([
+      if (enableBlankLine) const EmptyBlockSyntax(),
       if (enableAtxHeading && !enableHeadingId) const HeaderSyntax(),
       if (enableAtxHeading && enableHeadingId) const HeaderWithIdSyntax(),
       if (enableSetextHeading && !enableHeadingId) const SetextHeaderSyntax(),
@@ -131,11 +137,7 @@ class Markdown {
       if (enableHardLineBreak) LineBreakSyntax(),
       if (enableSoftLineBreak) SoftLineBreakSyntax(),
       if (enableBackslashEscape) EscapeSyntax(),
-      // "*" surrounded by spaces is left alone.
-      TextSyntax(r' \* ', startCharacter: $space),
-
-      // "_" surrounded by spaces is left alone.
-      TextSyntax(' _ ', startCharacter: $space),
+      if (enableDecodeHtml) DecodeHtmlSyntax(),
       if (enableEmphasis) ...[
         // Parse "**strong**" and "*emphasis*" tags.
         EmphasisSyntax.asterisk(),
@@ -143,7 +145,10 @@ class Markdown {
         // Parse "__strong__" and "_emphasis_" tags.
         EmphasisSyntax.underscore()
       ],
-      if (enableAutolink) AutolinkSyntax(),
+      if (enableAutolink) ...[
+        EmailAutolinkSyntax(),
+        AutolinkSyntax(),
+      ],
       if (enableAutolinkExtension) AutolinkExtensionSyntax(),
       if (enableCodeSpan) CodeSyntax(),
       if (enableStrikethrough) StrikethroughSyntax(),

--- a/lib/src/markdown.dart
+++ b/lib/src/markdown.dart
@@ -1,0 +1,225 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'ast.dart';
+import 'block_syntaxes/block_syntax.dart';
+import 'block_syntaxes/blockquote_syntax.dart';
+import 'block_syntaxes/code_block_syntax.dart';
+import 'block_syntaxes/fenced_blockquote_syntax.dart';
+import 'block_syntaxes/fenced_code_block_syntax.dart';
+import 'block_syntaxes/header_syntax.dart';
+import 'block_syntaxes/header_with_id_syntax.dart';
+import 'block_syntaxes/horizontal_rule_syntax.dart';
+import 'block_syntaxes/html_block_syntax.dart';
+import 'block_syntaxes/ordered_list_syntax.dart';
+import 'block_syntaxes/ordered_list_with_checkbox_syntax.dart';
+import 'block_syntaxes/paragraph_syntax.dart';
+import 'block_syntaxes/setext_header_syntax.dart';
+import 'block_syntaxes/setext_header_with_id_syntax.dart';
+import 'block_syntaxes/table_syntax.dart';
+import 'block_syntaxes/unordered_list_syntax.dart';
+import 'block_syntaxes/unordered_list_with_checkbox_syntax.dart';
+import 'charcode.dart';
+import 'document.dart';
+import 'inline_syntaxes/autolink_extension_syntax.dart';
+import 'inline_syntaxes/autolink_syntax.dart';
+import 'inline_syntaxes/code_syntax.dart';
+import 'inline_syntaxes/color_swatch_syntax.dart';
+import 'inline_syntaxes/emoji_syntax.dart';
+import 'inline_syntaxes/emphasis_syntax.dart';
+import 'inline_syntaxes/escape_html_syntax.dart';
+import 'inline_syntaxes/escape_syntax.dart';
+import 'inline_syntaxes/image_syntax.dart';
+import 'inline_syntaxes/inline_html_syntax.dart';
+import 'inline_syntaxes/inline_syntax.dart';
+import 'inline_syntaxes/line_break_syntax.dart';
+import 'inline_syntaxes/link_syntax.dart';
+import 'inline_syntaxes/soft_line_break_syntax.dart';
+import 'inline_syntaxes/strikethrough_syntax.dart';
+import 'inline_syntaxes/text_syntax.dart';
+import 'parsers/block_parser.dart';
+import 'parsers/inline_parser.dart';
+import 'syntax.dart';
+
+class Markdown {
+  final _blockSyntaxes = <BlockSyntax>{};
+  final _inlineSyntaxes = <InlineSyntax>{};
+  final bool hasCustomInlineSyntaxes;
+  final bool escapeHtml;
+
+  Iterable<BlockSyntax> get blockSyntaxes => _blockSyntaxes;
+  Iterable<InlineSyntax> get inlineSyntaxes => _inlineSyntaxes;
+
+  final linkReferences = <String, LinkReference>{};
+
+  Markdown({
+    bool enableAtxHeading = true,
+    bool enableHeadingId = false,
+    bool enableBlockquote = true,
+    bool enableIndentedCodeBlock = true,
+    bool enableFencedBlockquote = false,
+    bool enableFencedCodeBlock = true,
+    bool enableList = true,
+    bool enableSetextHeading = true,
+    bool enableTable = false,
+    bool enableHtmlBlock = true,
+    bool enableThematicBreak = true,
+    bool enableAutolinkExtension = false,
+    bool enableAutolink = true,
+    bool enableBackslashEscape = true,
+    bool enableCodeSpan = true,
+    bool enableEmoji = false,
+    bool enableColorSwatch = false,
+    bool enableEmphasis = true,
+    bool enableHardLineBreak = true,
+    bool enableImage = true,
+    bool enableLink = true,
+    bool enableRawHtml = true,
+    bool enableSoftLineBreak = true,
+    bool enableStrikethrough = false,
+    bool enableTaskList = false,
+    Resolver? linkResolver,
+    Resolver? imageLinkResolver,
+    Iterable<Syntax> extensions = const [],
+    this.escapeHtml = true,
+  }) : hasCustomInlineSyntaxes = extensions.any((e) => e is InlineSyntax) {
+    for (final syntax in extensions) {
+      if (syntax is BlockSyntax) {
+        _blockSyntaxes.add(syntax);
+      } else {
+        _inlineSyntaxes.add(syntax as InlineSyntax);
+      }
+    }
+
+    _blockSyntaxes.addAll([
+      if (enableAtxHeading && !enableHeadingId) const HeaderSyntax(),
+      if (enableAtxHeading && enableHeadingId) const HeaderWithIdSyntax(),
+      if (enableSetextHeading && !enableHeadingId) const SetextHeaderSyntax(),
+      if (enableSetextHeading && enableHeadingId)
+        const SetextHeaderWithIdSyntax(),
+      if (enableThematicBreak) const HorizontalRuleSyntax(),
+      if (enableList && !enableTaskList) ...[
+        const OrderedListSyntax(),
+        const UnorderedListSyntax(),
+      ],
+      if (enableList && enableTaskList) ...[
+        const OrderedListWithCheckboxSyntax(),
+        const UnorderedListWithCheckboxSyntax(),
+      ],
+      if (enableFencedBlockquote) const FencedBlockquoteSyntax(),
+      if (enableBlockquote) const BlockquoteSyntax(),
+      if (enableIndentedCodeBlock) const CodeBlockSyntax(),
+      if (enableFencedCodeBlock) const FencedCodeBlockSyntax(),
+      if (enableTable) const TableSyntax(),
+      if (enableHtmlBlock) const HtmlBlockSyntax(),
+      const ParagraphSyntax(),
+    ]);
+
+    _inlineSyntaxes.addAll([
+      // This first RegExp matches plain text to accelerate parsing. It's written
+      // so that it does not match any prefix of any following syntaxes. Most
+      // Markdown is plain text, so it's faster to match one RegExp per 'word'
+      // rather than fail to match all the following RegExps at each non-syntax
+      // character position.
+      if (!hasCustomInlineSyntaxes)
+        TextSyntax(r'[ \tA-Za-z0-9]*[A-Za-z0-9](?=\s)'),
+
+      // We should be less aggressive in blowing past "words".
+      if (hasCustomInlineSyntaxes) TextSyntax(r'[A-Za-z0-9]+(?=\s)'),
+
+      if (enableHardLineBreak) LineBreakSyntax(),
+      if (enableSoftLineBreak) SoftLineBreakSyntax(),
+      if (enableBackslashEscape) EscapeSyntax(),
+      // "*" surrounded by spaces is left alone.
+      TextSyntax(r' \* ', startCharacter: $space),
+
+      // "_" surrounded by spaces is left alone.
+      TextSyntax(' _ ', startCharacter: $space),
+      if (enableEmphasis) ...[
+        // Parse "**strong**" and "*emphasis*" tags.
+        EmphasisSyntax.asterisk(),
+
+        // Parse "__strong__" and "_emphasis_" tags.
+        EmphasisSyntax.underscore()
+      ],
+      if (enableAutolink) AutolinkSyntax(),
+      if (enableAutolinkExtension) AutolinkExtensionSyntax(),
+      if (enableCodeSpan) CodeSyntax(),
+      if (enableStrikethrough) StrikethroughSyntax(),
+      if (enableEmoji) EmojiSyntax(),
+      if (enableColorSwatch) ColorSwatchSyntax(),
+      if (enableLink) LinkSyntax(linkResolver: linkResolver),
+      if (enableImage) ImageSyntax(linkResolver: imageLinkResolver),
+      if (enableRawHtml) InlineHtmlSyntax(),
+      if (escapeHtml) ...[
+        EscapeHtmlSyntax(),
+        // Leave already-encoded HTML entities alone. Ensures we don't turn
+        // "&amp;" into "&amp;amp;"
+        TextSyntax('&[#a-zA-Z0-9]*;', startCharacter: $ampersand),
+      ],
+    ]);
+  }
+
+  /// The [commonMark] extension set is close to compliance with [CommonMark].
+  ///
+  /// [CommonMark]: http://commonmark.org/
+  factory Markdown.commonMark({bool escapeHtml = true}) =>
+      Markdown(escapeHtml: escapeHtml);
+
+  /// The [gitHubWeb] extension set renders Markdown similarly to GitHub.
+  ///
+  /// This is different from the [gitHubFlavored] extension set in that GitHub
+  /// actually renders HTML different from straight [GitHub flavored Markdown].
+  ///
+  /// (The only difference currently is that [gitHubWeb] renders headers with
+  /// linkable IDs.)
+  ///
+  /// [GitHub flavored Markdown]: https://github.github.com/gfm/
+  factory Markdown.gitHubWeb({bool escapeHtml = true}) => Markdown(
+        enableAutolinkExtension: true,
+        enableTable: true,
+        enableTaskList: true,
+        enableStrikethrough: true,
+        enableHeadingId: true,
+        enableColorSwatch: true,
+        enableEmoji: true,
+        escapeHtml: escapeHtml,
+      );
+
+  /// The [gitHubFlavored] extension set is close to compliance with the
+  /// [GitHub flavored Markdown spec](https://github.github.com/gfm/).
+  factory Markdown.gitHubFlavored({bool escapeHtml = true}) => Markdown(
+        enableAutolinkExtension: true,
+        enableTable: true,
+        enableTaskList: true,
+        enableStrikethrough: true,
+        escapeHtml: escapeHtml,
+      );
+
+  /// Parses the given string of Markdown to a series of AST nodes.
+  List<Node> parse(String text) {
+    // Replace windows line endings with unix line endings, and split.
+    final lines = text.replaceAll('\r\n', '\n').split('\n');
+    final nodes = BlockParser(lines, this).parseLines();
+    _parseInlineContent(nodes);
+    return nodes;
+  }
+
+  /// Parses the given inline Markdown [text] to a series of AST nodes.
+  List<Node> parseInline(String text) => InlineParser(text, this).parse();
+
+  void _parseInlineContent(List<Node> nodes) {
+    for (var i = 0; i < nodes.length; i++) {
+      final node = nodes[i];
+      if (node is UnparsedContent) {
+        final inlineNodes = parseInline(node.textContent);
+        nodes.removeAt(i);
+        nodes.insertAll(i, inlineNodes);
+        i += inlineNodes.length - 1;
+      } else if (node is Element && node.children != null) {
+        _parseInlineContent(node.children!);
+      }
+    }
+  }
+}

--- a/lib/src/parsers/block_parser.dart
+++ b/lib/src/parsers/block_parser.dart
@@ -1,0 +1,15 @@
+// Copyright (c) 2012, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import '../block_parser.dart' as deprecated_block_parser;
+import '../document.dart';
+import '../markdown.dart';
+
+/// Maintains the internal state needed to parse a series of lines into blocks
+/// of Markdown suitable for further inline parsing.
+// TODO(Zhiguang): merge in the old BlockParser in the next major version.
+class BlockParser extends deprecated_block_parser.BlockParser {
+  BlockParser(List<String> lines, Markdown markdown)
+      : super(lines, Document(), markdown: markdown);
+}

--- a/lib/src/parsers/inline_parser.dart
+++ b/lib/src/parsers/inline_parser.dart
@@ -1,0 +1,15 @@
+// Copyright (c) 2012, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import '../document.dart';
+import '../inline_parser.dart' as deprecated_inline_parser;
+import '../markdown.dart';
+
+/// Maintains the internal state needed to parse inline span elements in
+/// Markdown.
+// TODO(Zhiguang): merge in the old InlineParser in the next major version.
+class InlineParser extends deprecated_inline_parser.InlineParser {
+  InlineParser(String source, Markdown markdown)
+      : super(source, Document(), markdown: markdown);
+}

--- a/lib/src/syntax.dart
+++ b/lib/src/syntax.dart
@@ -1,0 +1,7 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+abstract class Syntax {
+  const Syntax();
+}

--- a/test/markdown_test.dart
+++ b/test/markdown_test.dart
@@ -8,6 +8,7 @@ import 'package:test/test.dart';
 import 'util.dart';
 
 void main() async {
+  testDirectoryDeprecated('original');
   testDirectory('original');
 
   // Block syntax extensions.
@@ -53,6 +54,9 @@ void main() async {
     'extensions/strikethrough.unit',
     inlineSyntaxes: [StrikethroughSyntax()],
   );
+
+  testDirectoryDeprecated('common_mark');
+  testDirectoryDeprecated('gfm');
 
   testDirectory('common_mark');
   testDirectory('gfm');


### PR DESCRIPTION
## Usage example of the new implementation

```dart
import 'package:markdown/markdown.dart';

void main() {
  const text = '# Hello "~~Markdown~~"!';

  Markdown( enableAtxHeading: false).parse(text).toHtml();
  // Output: <p># Hello &quot;~~Markdown~~&quot;!</p>

  Markdown.commonMark(escapeHtml: false).parse(text).toHtml();
  // Output: <h1>Hello "~~Markdown~~"!</h1>

  Markdown.gitHubFlavored().parse(text).toHtml();
  // Output: <h1>Hello &quot;<del>Markdown</del>&quot;!</h1>

  Markdown.gitHubWeb().parse(text).toHtml();
  // Output: <h1 id="hello-markdown">Hello &quot;<del>Markdown</del>&quot;!</h1>

  Markdown.gitHubFlavored(escapeHtml: false).parseInline(text).toHtml();
  // Output: # Hello "<del>Markdown</del>"!

  Markdown(
    extensions: [HighlightSyntax()],
  ).parse('==Markdown==').toHtml();
  // output: <p><mark>Markdown</mark></p>
}

class HighlightSyntax extends DelimiterSyntax {
  HighlightSyntax()
      : super('=+',
            requiresDelimiterRun: true,
            allowIntraWord: true,
            tags: [DelimiterTag('mark', 2)]);
}
```

## Major change

### 1. Deprecate `Document`, use `Markdown` instead

With the current `Document` implementation, if a user wants to have only some syntaxes enabled, the only way to achieve that is set both `withDefaultInlineSyntaxes` and `withDefaultBlockSyntaxes` to `false` and pass in the desired syntaxes through `blockSyntaxes` and `inlineSyntaxes`, it is tedious also easy to make mistakes, for example the order of syntaxes matters, you can not put `InlineHtmlSyntax` after `EscapeHtmlSyntax`, `ParagraphSyntax` must be the last block syntax etc.

### 2. Deprecate markdownToHtml(), use List<Node>.toHtml() instead.

We have to maintain these tens of parameters which will be passed to `Markdown` class if we keep the `markdownToHtml()` function, also `List<Node>.toHtml()` is more elegant.

### 3. Deprecate `ExtensionSet`, use `Markdown` factory constructors instead.

### 4. `blockSyntaxes` and `inlineSyntaxes` options of `Document` class vs `extensions` option of `Markdown` class.

They do not make a big difference, just make it simpler to pass in custom syntaxes.
