### PR TITLE
introduce a Line class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,6 @@
   line ending.
 * Add a new syntax `EscapeHtmlSyntax` to encode (`"`), (`<`), (`>`) and (`&`).
 * Add an option `caseSensitive` to `TextSyntax`.
-* **Breaking change**: Change the type of `parseLines`'s parameter from `String`
-  to `List<Line>`
 * Add a new public method `parse(String text)` for `Document`.
 
 ## 6.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
   `indicatorForCheckedCheckBox`, and `indicatorForUncheckedCheckBox`.
 * **Breaking change**: Removed `BlockHtmlSyntax`, `BlockTagBlockHtmlSyntax`,
   `LongBlockHtmlSyntax`, and `OtherTagBlockHtmlSyntax`.
+* **Breaking change**: Change the `line` properties of type `String` to `Line`.
+* **Breaking change**: Change the `lines` properties of type `List<String>` to
+  `List<Line>`.
 * Add a new syntax `HtmlBlockSyntax` to parse HTML blocks.
 * Add a new syntax `DecodeHtmlSyntax` to decode HTML entity and numeric
   character references.
@@ -16,9 +19,6 @@
 * Add a new public method `parse(String text)` for `Document`.
 * Add a new public method `parseLineList(List<Line> text)` for `Document`.
 * Add a new type: `Line`.
-* **Breaking change**: Change the `line` properties of type `String` to `Line`.
-* **Breaking change**: Change the `lines` properties of type `List<String>` to
-  `List<Line>`.
 
 ## 6.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@
 * Add a new syntax `EscapeHtmlSyntax` to encode (`"`), (`<`), (`>`) and (`&`).
 * Add an option `caseSensitive` to `TextSyntax`.
 * Add a new public method `parse(String text)` for `Document`.
+* Add a new public method `parseLineList(List<Line> text)` for `Document`.
+* Add a new type: `Line`.
+* **Breaking change**: Change all the `String` type **_line_** to `Line` type.
+* **Breaking change**: Change all the `List<String>` type **_lines_** to
+  `List<Line>` type.
 
 ## 6.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
   line ending.
 * Add a new syntax `EscapeHtmlSyntax` to encode (`"`), (`<`), (`>`) and (`&`).
 * Add an option `caseSensitive` to `TextSyntax`.
+* **Breaking change**: Change the type of `parseLines`'s parameter from `String`
+  to `List<Line>`
+* Add a new public method `parse(String text)` for `Document`.
 
 ## 6.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,9 @@
 * Add a new public method `parse(String text)` for `Document`.
 * Add a new public method `parseLineList(List<Line> text)` for `Document`.
 * Add a new type: `Line`.
-* **Breaking change**: Change all the `String` type **_line_** to `Line` type.
-* **Breaking change**: Change all the `List<String>` type **_lines_** to
-  `List<Line>` type.
+* **Breaking change**: Change the `line` properties of type `String` to `Line`.
+* **Breaking change**: Change the `lines` properties of type `List<String>` to
+  `List<Line>`.
 
 ## 6.0.1
 

--- a/lib/markdown.dart
+++ b/lib/markdown.dart
@@ -82,5 +82,6 @@ export 'src/inline_syntaxes/link_syntax.dart';
 export 'src/inline_syntaxes/soft_line_break_syntax.dart';
 export 'src/inline_syntaxes/strikethrough_syntax.dart';
 export 'src/inline_syntaxes/text_syntax.dart';
+export 'src/line.dart';
 
 const version = packageVersion;

--- a/lib/src/block_parser.dart
+++ b/lib/src/block_parser.dart
@@ -16,11 +16,12 @@ import 'block_syntaxes/paragraph_syntax.dart';
 import 'block_syntaxes/setext_header_syntax.dart';
 import 'block_syntaxes/unordered_list_syntax.dart';
 import 'document.dart';
+import 'line.dart';
 
 /// Maintains the internal state needed to parse a series of lines into blocks
 /// of Markdown suitable for further inline parsing.
 class BlockParser {
-  final List<String> lines;
+  final List<Line> lines;
 
   /// The Markdown document this parser is parsing.
   final Document document;
@@ -63,10 +64,10 @@ class BlockParser {
   }
 
   /// Gets the current line.
-  String get current => lines[_pos];
+  Line get current => lines[_pos];
 
   /// Gets the line after the current one or `null` if there is none.
-  String? get next {
+  Line? get next {
     // Don't read past the end.
     if (_pos >= lines.length - 1) return null;
     return lines[_pos + 1];
@@ -78,7 +79,7 @@ class BlockParser {
   /// `peek(0)` is equivalent to [current].
   ///
   /// `peek(1)` is equivalent to [next].
-  String? peek(int linesAhead) {
+  Line? peek(int linesAhead) {
     if (linesAhead < 0) {
       throw ArgumentError('Invalid linesAhead: $linesAhead; must be >= 0.');
     }
@@ -100,13 +101,13 @@ class BlockParser {
   /// Gets whether or not the current line matches the given pattern.
   bool matches(RegExp regex) {
     if (isDone) return false;
-    return regex.hasMatch(current);
+    return regex.hasMatch(current.content);
   }
 
   /// Gets whether or not the next line matches the given pattern.
   bool matchesNext(RegExp regex) {
     if (next == null) return false;
-    return regex.hasMatch(next!);
+    return regex.hasMatch(next!.content);
   }
 
   List<Node> parseLines() {

--- a/lib/src/block_syntaxes/block_syntax.dart
+++ b/lib/src/block_syntaxes/block_syntax.dart
@@ -4,6 +4,7 @@
 
 import '../ast.dart';
 import '../block_parser.dart';
+import '../line.dart';
 
 abstract class BlockSyntax {
   const BlockSyntax();
@@ -14,19 +15,19 @@ abstract class BlockSyntax {
   bool canEndBlock(BlockParser parser) => true;
 
   bool canParse(BlockParser parser) {
-    return pattern.hasMatch(parser.current);
+    return pattern.hasMatch(parser.current.content);
   }
 
   Node? parse(BlockParser parser);
 
-  List<String?> parseChildLines(BlockParser parser) {
+  List<Line?> parseChildLines(BlockParser parser) {
     // Grab all of the lines that form the block element.
-    final childLines = <String?>[];
+    final childLines = <Line?>[];
 
     while (!parser.isDone) {
-      final match = pattern.firstMatch(parser.current);
+      final match = pattern.firstMatch(parser.current.content);
       if (match == null) break;
-      childLines.add(match[1]);
+      childLines.add(parser.current);
       parser.advance();
     }
 

--- a/lib/src/block_syntaxes/code_block_syntax.dart
+++ b/lib/src/block_syntaxes/code_block_syntax.dart
@@ -4,6 +4,7 @@
 
 import '../ast.dart';
 import '../block_parser.dart';
+import '../line.dart';
 import '../patterns.dart';
 import '../util.dart';
 import 'block_syntax.dart';
@@ -19,21 +20,21 @@ class CodeBlockSyntax extends BlockSyntax {
   const CodeBlockSyntax();
 
   @override
-  List<String?> parseChildLines(BlockParser parser) {
-    final childLines = <String?>[];
+  List<Line> parseChildLines(BlockParser parser) {
+    final childLines = <Line>[];
 
     while (!parser.isDone) {
-      final isBlankLine = parser.current.isBlank;
+      final isBlankLine = parser.current.isBlankLine;
       if (isBlankLine && _shouldEnd(parser)) {
         break;
       }
 
       if (!isBlankLine &&
           childLines.isNotEmpty &&
-          pattern.hasMatch(parser.current) != true) {
+          pattern.hasMatch(parser.current.content) != true) {
         break;
       }
-      childLines.add(parser.current.dedent().text);
+      childLines.add(Line(parser.current.content.dedent().text));
 
       parser.advance();
     }
@@ -46,9 +47,9 @@ class CodeBlockSyntax extends BlockSyntax {
     final childLines = parseChildLines(parser);
 
     // The Markdown tests expect a trailing newline.
-    childLines.add('');
+    childLines.add(const Line(''));
 
-    var content = childLines.join('\n');
+    var content = childLines.map((e) => e.content).join('\n');
     if (parser.document.encodeHtml) {
       content = escapeHtml(content);
     }
@@ -67,12 +68,12 @@ class CodeBlockSyntax extends BlockSyntax {
 
       // It does not matter how many blank lines between chunks:
       // https://spec.commonmark.org/0.30/#example-111
-      if (nextLine.isBlank) {
+      if (nextLine.isBlankLine) {
         i++;
         continue;
       }
 
-      return pattern.hasMatch(nextLine) == false;
+      return pattern.hasMatch(nextLine.content) == false;
     }
   }
 }

--- a/lib/src/block_syntaxes/code_block_syntax.dart
+++ b/lib/src/block_syntaxes/code_block_syntax.dart
@@ -47,7 +47,7 @@ class CodeBlockSyntax extends BlockSyntax {
     final childLines = parseChildLines(parser);
 
     // The Markdown tests expect a trailing newline.
-    childLines.add(const Line(''));
+    childLines.add(Line(''));
 
     var content = childLines.map((e) => e.content).join('\n');
     if (parser.document.encodeHtml) {

--- a/lib/src/block_syntaxes/dummy_block_syntax.dart
+++ b/lib/src/block_syntaxes/dummy_block_syntax.dart
@@ -27,7 +27,7 @@ class DummyBlockSyntax extends BlockSyntax {
     final childLines = <String>[];
 
     while (!BlockSyntax.isAtBlockEnd(parser)) {
-      childLines.add(parser.current);
+      childLines.add(parser.current.content);
       parser.advance();
     }
 

--- a/lib/src/block_syntaxes/fenced_blockquote_syntax.dart
+++ b/lib/src/block_syntaxes/fenced_blockquote_syntax.dart
@@ -4,6 +4,7 @@
 
 import '../ast.dart';
 import '../block_parser.dart';
+import '../line.dart';
 import '../patterns.dart';
 import 'block_syntax.dart';
 
@@ -15,12 +16,12 @@ class FencedBlockquoteSyntax extends BlockSyntax {
   RegExp get pattern => blockquoteFencePattern;
 
   @override
-  List<String> parseChildLines(BlockParser parser) {
-    final childLines = <String>[];
+  List<Line> parseChildLines(BlockParser parser) {
+    final childLines = <Line>[];
     parser.advance();
 
     while (!parser.isDone) {
-      final match = pattern.hasMatch(parser.current);
+      final match = pattern.hasMatch(parser.current.content);
       if (!match) {
         childLines.add(parser.current);
         parser.advance();

--- a/lib/src/block_syntaxes/header_syntax.dart
+++ b/lib/src/block_syntaxes/header_syntax.dart
@@ -16,7 +16,7 @@ class HeaderSyntax extends BlockSyntax {
 
   @override
   Node parse(BlockParser parser) {
-    final match = pattern.firstMatch(parser.current)!;
+    final match = pattern.firstMatch(parser.current.content)!;
     final matchedText = match[0]!;
     final openMarker = match[1]!;
     final closeMarker = match[2];
@@ -26,10 +26,13 @@ class HeaderSyntax extends BlockSyntax {
 
     String? content;
     if (closeMarker == null) {
-      content = parser.current.substring(openMarkerEnd);
+      content = parser.current.content.substring(openMarkerEnd);
     } else {
       final closeMarkerStart = matchedText.lastIndexOf(closeMarker);
-      content = parser.current.substring(openMarkerEnd, closeMarkerStart);
+      content = parser.current.content.substring(
+        openMarkerEnd,
+        closeMarkerStart,
+      );
     }
     content = content.trim();
 

--- a/lib/src/block_syntaxes/html_block_syntax.dart
+++ b/lib/src/block_syntaxes/html_block_syntax.dart
@@ -4,6 +4,7 @@
 
 import '../ast.dart';
 import '../block_parser.dart';
+import '../line.dart';
 import '../patterns.dart';
 import 'block_syntax.dart';
 
@@ -21,7 +22,8 @@ class HtmlBlockSyntax extends BlockSyntax {
   // more detail.
   @override
   bool canEndBlock(BlockParser parser) =>
-      pattern.firstMatch(parser.current)!.namedGroup('condition_7') == null;
+      pattern.firstMatch(parser.current.content)!.namedGroup('condition_7') ==
+      null;
 
   static final _endConditions = [
     // For condition 1, it does not need to match the start tag, see
@@ -38,10 +40,10 @@ class HtmlBlockSyntax extends BlockSyntax {
   const HtmlBlockSyntax();
 
   @override
-  List<String> parseChildLines(BlockParser parser) {
-    final lines = <String>[];
+  List<Line> parseChildLines(BlockParser parser) {
+    final lines = <Line>[];
 
-    final match = pattern.firstMatch(parser.current);
+    final match = pattern.firstMatch(parser.current.content);
     var matchedCondition = 0;
     for (var i = 0; i < match!.groupCount; i++) {
       if (match.group(i + 1) != null) {
@@ -55,14 +57,14 @@ class HtmlBlockSyntax extends BlockSyntax {
       lines.add(parser.current);
       parser.advance();
 
-      while (!parser.isDone && !endCondition.hasMatch(parser.current)) {
+      while (!parser.isDone && !endCondition.hasMatch(parser.current.content)) {
         lines.add(parser.current);
         parser.advance();
       }
     } else {
       while (!parser.isDone) {
         lines.add(parser.current);
-        if (endCondition.hasMatch(parser.current)) {
+        if (endCondition.hasMatch(parser.current.content)) {
           break;
         }
         parser.advance();
@@ -74,7 +76,7 @@ class HtmlBlockSyntax extends BlockSyntax {
     // current HTML block.
     if (!parser.isDone &&
         parser.next != null &&
-        pattern.hasMatch(parser.next!)) {
+        pattern.hasMatch(parser.next!.content)) {
       parser.advance();
       lines.addAll(parseChildLines(parser));
     }
@@ -85,6 +87,6 @@ class HtmlBlockSyntax extends BlockSyntax {
   @override
   Node parse(BlockParser parser) {
     final childLines = parseChildLines(parser);
-    return Text(childLines.join('\n').trimRight());
+    return Text(childLines.map((e) => e.content).join('\n').trimRight());
   }
 }

--- a/lib/src/block_syntaxes/list_syntax.dart
+++ b/lib/src/block_syntaxes/list_syntax.dart
@@ -4,6 +4,7 @@
 
 import '../ast.dart';
 import '../block_parser.dart';
+import '../line.dart';
 import '../patterns.dart';
 import 'block_syntax.dart';
 import 'ordered_list_with_checkbox_syntax.dart';
@@ -15,7 +16,7 @@ class ListItem {
     this.taskListItemState,
   });
 
-  final List<String> lines;
+  final List<Line> lines;
   final TaskListItemState? taskListItemState;
 }
 
@@ -30,7 +31,7 @@ abstract class ListSyntax extends BlockSyntax {
     // Ideally, [BlockSyntax.canEndBlock] should be changed to be a method
     // which accepts a [BlockParser], but this would be a breaking change,
     // so we're going with this temporarily.
-    final match = pattern.firstMatch(parser.current)!;
+    final match = pattern.firstMatch(parser.current.content)!;
     // The seventh group, in both [olPattern] and [ulPattern] is the text
     // after the delimiter.
     return match[7]?.isNotEmpty ?? false;
@@ -57,13 +58,13 @@ abstract class ListSyntax extends BlockSyntax {
     final taskListParserEnabled = this is UnorderedListWithCheckboxSyntax ||
         this is OrderedListWithCheckboxSyntax;
     final items = <ListItem>[];
-    var childLines = <String>[];
+    var childLines = <Line>[];
     TaskListItemState? taskListItemState;
 
     void endItem() {
       if (childLines.isNotEmpty) {
         items.add(ListItem(childLines, taskListItemState: taskListItemState));
-        childLines = <String>[];
+        childLines = <Line>[];
       }
     }
 
@@ -86,7 +87,7 @@ abstract class ListSyntax extends BlockSyntax {
 
     late Match? possibleMatch;
     bool tryMatch(RegExp pattern) {
-      possibleMatch = pattern.firstMatch(parser.current);
+      possibleMatch = pattern.firstMatch(parser.current.content);
       return possibleMatch != null;
     }
 
@@ -98,21 +99,21 @@ abstract class ListSyntax extends BlockSyntax {
 
     while (!parser.isDone) {
       final leadingSpace =
-          _whitespaceRe.matchAsPrefix(parser.current)!.group(0)!;
+          _whitespaceRe.matchAsPrefix(parser.current.content)!.group(0)!;
       final leadingExpandedTabLength = _expandedTabLength(leadingSpace);
-      if (emptyPattern.hasMatch(parser.current)) {
-        if (emptyPattern.hasMatch(parser.next ?? '')) {
+      if (parser.current.isBlankLine) {
+        if (parser.next?.isBlankLine ?? true) {
           // Two blank lines ends a list.
           break;
         }
         // Add a blank line to the current list item.
-        childLines.add('');
+        childLines.add(const Line(''));
       } else if (indent != null && indent.length <= leadingExpandedTabLength) {
         // Strip off indent and add to current item.
-        final line = parser.current
+        final line = parser.current.content
             .replaceFirst(leadingSpace, ' ' * leadingExpandedTabLength)
             .replaceFirst(indent, '');
-        childLines.add(parseTaskListItem(line));
+        childLines.add(Line(parseTaskListItem(line)));
       } else if (tryMatch(hrPattern)) {
         // Horizontal rule takes precedence to a new list item.
         break;
@@ -156,14 +157,14 @@ abstract class ListSyntax extends BlockSyntax {
         }
         // End the current list item and start a new one.
         endItem();
-        childLines.add(parseTaskListItem('$restWhitespace$content'));
+        childLines.add(Line(parseTaskListItem('$restWhitespace$content')));
       } else if (BlockSyntax.isAtBlockEnd(parser)) {
         // Done with the list.
         break;
       } else {
         // If the previous item is a blank line, this means we're done with the
         // list and are starting a new top-level paragraph.
-        if ((childLines.isNotEmpty) && (childLines.last == '')) {
+        if (childLines.isNotEmpty && childLines.last.isBlankLine) {
           parser.encounteredBlankLine = true;
           break;
         }
@@ -238,7 +239,7 @@ abstract class ListSyntax extends BlockSyntax {
   }
 
   void _removeLeadingEmptyLine(ListItem item) {
-    if (item.lines.isNotEmpty && emptyPattern.hasMatch(item.lines.first)) {
+    if (item.lines.isNotEmpty && item.lines.first.isBlankLine) {
       item.lines.removeAt(0);
     }
   }
@@ -249,8 +250,7 @@ abstract class ListSyntax extends BlockSyntax {
     var anyEmpty = false;
     for (var i = 0; i < items.length; i++) {
       if (items[i].lines.length == 1) continue;
-      while (items[i].lines.isNotEmpty &&
-          emptyPattern.hasMatch(items[i].lines.last)) {
+      while (items[i].lines.isNotEmpty && items[i].lines.last.isBlankLine) {
         if (i < items.length - 1) {
           anyEmpty = true;
         }

--- a/lib/src/block_syntaxes/list_syntax.dart
+++ b/lib/src/block_syntaxes/list_syntax.dart
@@ -107,7 +107,7 @@ abstract class ListSyntax extends BlockSyntax {
           break;
         }
         // Add a blank line to the current list item.
-        childLines.add(const Line(''));
+        childLines.add(Line(''));
       } else if (indent != null && indent.length <= leadingExpandedTabLength) {
         // Strip off indent and add to current item.
         final line = parser.current.content

--- a/lib/src/block_syntaxes/paragraph_syntax.dart
+++ b/lib/src/block_syntaxes/paragraph_syntax.dart
@@ -32,7 +32,7 @@ class ParagraphSyntax extends BlockSyntax {
 
     // Eat until we hit something that ends a paragraph.
     while (!BlockSyntax.isAtBlockEnd(parser)) {
-      childLines.add(parser.current);
+      childLines.add(parser.current.content);
       parser.advance();
     }
 

--- a/lib/src/block_syntaxes/setext_header_syntax.dart
+++ b/lib/src/block_syntaxes/setext_header_syntax.dart
@@ -16,7 +16,7 @@ class SetextHeaderSyntax extends BlockSyntax {
 
   @override
   bool canParse(BlockParser parser) {
-    if (!_interperableAsParagraph(parser.current)) return false;
+    if (!_interperableAsParagraph(parser.current.content)) return false;
     var i = 1;
     while (true) {
       final nextLine = parser.peek(i);
@@ -24,11 +24,11 @@ class SetextHeaderSyntax extends BlockSyntax {
         // We never reached an underline.
         return false;
       }
-      if (setextPattern.hasMatch(nextLine)) {
+      if (setextPattern.hasMatch(nextLine.content)) {
         return true;
       }
       // Ensure that we're still in something like paragraph text.
-      if (!_interperableAsParagraph(nextLine)) {
+      if (!_interperableAsParagraph(nextLine.content)) {
         return false;
       }
       i++;
@@ -40,10 +40,10 @@ class SetextHeaderSyntax extends BlockSyntax {
     final lines = <String>[];
     String? tag;
     while (!parser.isDone) {
-      final match = setextPattern.firstMatch(parser.current);
+      final match = setextPattern.firstMatch(parser.current.content);
       if (match == null) {
         // More text.
-        lines.add(parser.current);
+        lines.add(parser.current.content);
         parser.advance();
         continue;
       } else {

--- a/lib/src/block_syntaxes/table_syntax.dart
+++ b/lib/src/block_syntaxes/table_syntax.dart
@@ -32,7 +32,7 @@ class TableSyntax extends BlockSyntax {
   /// * many body rows of body cells (`<td>` cells)
   @override
   Node? parse(BlockParser parser) {
-    final alignments = _parseAlignments(parser.next!);
+    final alignments = _parseAlignments(parser.next!.content);
     final columnCount = alignments.length;
     final headRow = _parseRow(parser, alignments, 'th');
     if (headRow.children!.length != columnCount) {
@@ -122,19 +122,19 @@ class TableSyntax extends BlockSyntax {
   ) {
     final line = parser.current;
     final cells = <String>[];
-    var index = _walkPastOpeningPipe(line);
+    var index = _walkPastOpeningPipe(line.content);
     final cellBuffer = StringBuffer();
 
     while (true) {
-      if (index >= line.length) {
+      if (index >= line.content.length) {
         // This row ended without a trailing pipe, which is fine.
         cells.add(cellBuffer.toString().trimRight());
         cellBuffer.clear();
         break;
       }
-      final ch = line.codeUnitAt(index);
+      final ch = line.content.codeUnitAt(index);
       if (ch == $backslash) {
-        if (index == line.length - 1) {
+        if (index == line.content.length - 1) {
           // A table row ending in a backslash is not well-specified, but it
           // looks like GitHub just allows the character as part of the text of
           // the last cell.
@@ -143,7 +143,7 @@ class TableSyntax extends BlockSyntax {
           cellBuffer.clear();
           break;
         }
-        final escaped = line.codeUnitAt(index + 1);
+        final escaped = line.content.codeUnitAt(index + 1);
         if (escaped == $pipe) {
           // GitHub Flavored Markdown has a strange bit here; the pipe is to be
           // escaped before any other inline processing. One consequence, for
@@ -163,8 +163,8 @@ class TableSyntax extends BlockSyntax {
         cellBuffer.clear();
         // Walk forward past any whitespace which leads the next cell.
         index++;
-        index = _walkPastWhitespace(line, index);
-        if (index >= line.length) {
+        index = _walkPastWhitespace(line.content, index);
+        if (index >= line.content.length) {
           // This row ended with a trailing pipe.
           break;
         }

--- a/lib/src/block_syntaxes/unordered_list_syntax.dart
+++ b/lib/src/block_syntaxes/unordered_list_syntax.dart
@@ -19,11 +19,11 @@ class UnorderedListSyntax extends ListSyntax {
     // ```
     // * * *
     // ```
-    if (hrPattern.hasMatch(parser.current)) {
+    if (hrPattern.hasMatch(parser.current.content)) {
       return false;
     }
 
-    return pattern.hasMatch(parser.current);
+    return pattern.hasMatch(parser.current.content);
   }
 
   @override

--- a/lib/src/document.dart
+++ b/lib/src/document.dart
@@ -67,11 +67,15 @@ class Document {
     }
   }
 
-  /// Parses the given [text] to a series of AST nodes.
-  List<Node> parse(String text) => parseLines(text.toLines());
-
   /// Parses the given [lines] of Markdown to a series of AST nodes.
-  List<Node> parseLines(List<Line> lines) {
+  List<Node> parseLines(List<String> lines) =>
+      parseLineList(lines.map(Line.new).toList());
+
+  /// Parses the given [text] to a series of AST nodes.
+  List<Node> parse(String text) => parseLineList(text.toLines());
+
+  /// Parses the given [lines] of [Line] to a series of AST nodes.
+  List<Node> parseLineList(List<Line> lines) {
     final nodes = BlockParser(lines, this).parseLines();
     _parseInlineContent(nodes);
     return nodes;

--- a/lib/src/document.dart
+++ b/lib/src/document.dart
@@ -8,6 +8,8 @@ import 'block_syntaxes/block_syntax.dart';
 import 'extension_set.dart';
 import 'inline_parser.dart';
 import 'inline_syntaxes/inline_syntax.dart';
+import 'line.dart';
+import 'util.dart';
 
 /// Maintains the context needed to parse a Markdown document.
 class Document {
@@ -65,8 +67,11 @@ class Document {
     }
   }
 
+  /// Parses the given [text] to a series of AST nodes.
+  List<Node> parse(String text) => parseLines(text.toLines());
+
   /// Parses the given [lines] of Markdown to a series of AST nodes.
-  List<Node> parseLines(List<String> lines) {
+  List<Node> parseLines(List<Line> lines) {
     final nodes = BlockParser(lines, this).parseLines();
     _parseInlineContent(nodes);
     return nodes;

--- a/lib/src/html_renderer.dart
+++ b/lib/src/html_renderer.dart
@@ -36,10 +36,7 @@ String markdownToHtml(
 
   if (inlineOnly) return renderToHtml(document.parseInline(markdown));
 
-  // Replace windows line endings with unix line endings, and split.
-  final lines = markdown.replaceAll('\r\n', '\n').split('\n');
-
-  final nodes = document.parseLines(lines);
+  final nodes = document.parse(markdown);
 
   return '${renderToHtml(nodes)}\n';
 }

--- a/lib/src/line.dart
+++ b/lib/src/line.dart
@@ -14,6 +14,25 @@ class Line {
 
   /// How many spaces of a tab that remains after part of it has been consumed.
   // See: https://spec.commonmark.org/0.30/#example-6
+  // We cannot simply expand the `tabRemaining` to spaces, for example
+  //
+  // `>\t\tfoo`
+  //
+  // If we expand the 2 space width `tabRemaining` from blockquote block into 2
+  // spaces, so the string segment for the indented code block is:
+  //
+  // `  \tfoo`,
+  //
+  // then the output will be:
+  // ```html
+  // <pre><code>foo
+  // </code></pre>
+  // ```
+  // instead of the expected:
+  // ```html
+  // <pre><code>  foo
+  // </code></pre>
+  // ```
   final int? tabRemaining;
 
   // A line containing no characters, or a line containing only spaces

--- a/lib/src/line.dart
+++ b/lib/src/line.dart
@@ -38,10 +38,10 @@ class Line {
   // A line containing no characters, or a line containing only spaces
   // (`U+0020`) or tabs (`U+0009`), is called a blank line.
   // https://spec.commonmark.org/0.30/#blank-line
-  bool get isBlankLine => emptyPattern.hasMatch(content);
+  final bool isBlankLine;
 
-  const Line(
+  Line(
     this.content, {
     this.tabRemaining,
-  });
+  }) : isBlankLine = emptyPattern.hasMatch(content);
 }

--- a/lib/src/line.dart
+++ b/lib/src/line.dart
@@ -1,0 +1,34 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'patterns.dart';
+
+/// A [Line] is a sequence of zero or more characters other than line feed
+/// (`U+000A`) or carriage return (`U+000D`), followed by a line ending or by
+/// the end of file.
+// See https://spec.commonmark.org/0.30/#line.
+class Line {
+  /// A sequence of zero or more characters other than the line ending.
+  final String content;
+
+  /// How many spaces of a tab that remains after part of it has been consumed.
+  // See: https://spec.commonmark.org/0.30/#example-6
+  final int? tabRemaining;
+
+  // A line containing no characters, or a line containing only spaces
+  // (`U+0020`) or tabs (`U+0009`), is called a blank line.
+  // https://spec.commonmark.org/0.30/#blank-line
+  bool get isBlankLine => emptyPattern.hasMatch(content);
+
+  const Line(
+    this.content, {
+    this.tabRemaining,
+  });
+
+  Map<String, dynamic> toMap() => {
+        'content': content,
+        'isBlankLine': isBlankLine,
+        if (tabRemaining != null) 'tabRemaining': tabRemaining,
+      };
+}

--- a/lib/src/line.dart
+++ b/lib/src/line.dart
@@ -44,10 +44,4 @@ class Line {
     this.content, {
     this.tabRemaining,
   });
-
-  Map<String, dynamic> toMap() => {
-        'content': content,
-        'isBlankLine': isBlankLine,
-        if (tabRemaining != null) 'tabRemaining': tabRemaining,
-      };
 }

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -7,6 +7,7 @@ import 'dart:convert';
 import 'assets/case_folding.dart';
 import 'assets/html_entities.dart';
 import 'charcode.dart';
+import 'line.dart';
 import 'patterns.dart';
 
 /// One or more whitespace, for compressing.
@@ -171,6 +172,9 @@ extension StringExtensions on String {
 
   /// Whether this string contains only whitespaces.
   bool get isBlank => trim().isEmpty;
+
+  /// Converts this string to a list of [Line].
+  List<Line> toLines() => LineSplitter.split(this).map(Line.new).toList();
 }
 
 /// A class that describes a dedented text.

--- a/test/document_test.dart
+++ b/test/document_test.dart
@@ -2,9 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:convert';
-
 import 'package:markdown/markdown.dart';
+import 'package:markdown/src/util.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -33,7 +32,7 @@ void main() {
       });
 
       test('encodes HTML in a fenced code block', () {
-        final lines = '```\n<p>Hello <em>Markdown</em></p>\n```\n'.split('\n');
+        final lines = '```\n<p>Hello <em>Markdown</em></p>\n```\n'.toLines();
         final result = document.parseLines(lines);
         final codeBlock = result.single as Element;
         expect(
@@ -43,7 +42,7 @@ void main() {
       });
 
       test('encodes HTML in an indented code block', () {
-        final lines = '    <p>Hello <em>Markdown</em></p>\n'.split('\n');
+        final lines = '    <p>Hello <em>Markdown</em></p>\n'.toLines();
         final result = document.parseLines(lines);
         final codeBlock = result.single as Element;
         expect(
@@ -56,8 +55,7 @@ void main() {
         // Example to get a <p> tag rendered before a text node.
         const contents = 'Sample\n\n<pre>\n A\n B\n</pre>';
         final document = Document();
-        final lines = LineSplitter.split(contents).toList();
-        final nodes = BlockParser(lines, document).parseLines();
+        final nodes = BlockParser(contents.toLines(), document).parseLines();
         final result = HtmlRenderer().render(nodes);
         expect(result, '<p>\n</p><pre>\n A\n B\n</pre>');
       });
@@ -93,7 +91,7 @@ void main() {
       });
 
       test('leaves HTML alone, in a fenced code block', () {
-        final lines = '```\n<p>Hello <em>Markdown</em></p>\n```\n'.split('\n');
+        final lines = '```\n<p>Hello <em>Markdown</em></p>\n```\n'.toLines();
         final result = document.parseLines(lines);
         final codeBlock = result.single as Element;
         expect(
@@ -103,7 +101,7 @@ void main() {
       });
 
       test('leaves HTML alone, in an indented code block', () {
-        final lines = '    <p>Hello <em>Markdown</em></p>\n'.split('\n');
+        final lines = '    <p>Hello <em>Markdown</em></p>\n'.toLines();
         final result = document.parseLines(lines);
         final codeBlock = result.single as Element;
         expect(

--- a/test/document_test.dart
+++ b/test/document_test.dart
@@ -33,7 +33,7 @@ void main() {
 
       test('encodes HTML in a fenced code block', () {
         final lines = '```\n<p>Hello <em>Markdown</em></p>\n```\n'.toLines();
-        final result = document.parseLines(lines);
+        final result = document.parseLineList(lines);
         final codeBlock = result.single as Element;
         expect(
           codeBlock.textContent,
@@ -43,7 +43,7 @@ void main() {
 
       test('encodes HTML in an indented code block', () {
         final lines = '    <p>Hello <em>Markdown</em></p>\n'.toLines();
-        final result = document.parseLines(lines);
+        final result = document.parseLineList(lines);
         final codeBlock = result.single as Element;
         expect(
           codeBlock.textContent,
@@ -92,7 +92,7 @@ void main() {
 
       test('leaves HTML alone, in a fenced code block', () {
         final lines = '```\n<p>Hello <em>Markdown</em></p>\n```\n'.toLines();
-        final result = document.parseLines(lines);
+        final result = document.parseLineList(lines);
         final codeBlock = result.single as Element;
         expect(
           codeBlock.textContent,
@@ -102,7 +102,7 @@ void main() {
 
       test('leaves HTML alone, in an indented code block', () {
         final lines = '    <p>Hello <em>Markdown</em></p>\n'.toLines();
-        final result = document.parseLines(lines);
+        final result = document.parseLineList(lines);
         final codeBlock = result.single as Element;
         expect(
           codeBlock.textContent,

--- a/test/util_test.dart
+++ b/test/util_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:markdown/markdown.dart';
 import 'package:markdown/src/util.dart';
 import 'package:test/test.dart';
 
@@ -51,4 +52,12 @@ void main() {
       ]);
     });
   });
+}
+
+extension LineX on Line {
+  Map<String, dynamic> toMap() => {
+        'content': content,
+        'isBlankLine': isBlankLine,
+        if (tabRemaining != null) 'tabRemaining': tabRemaining,
+      };
 }

--- a/test/util_test.dart
+++ b/test/util_test.dart
@@ -1,0 +1,54 @@
+// Copyright (c) 2012, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:markdown/src/util.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('String.toLines()', () {
+    test('a single line without a line ending', () {
+      const text = 'Foo';
+      final lines = text.toLines();
+
+      expect(lines.map((e) => e.toMap()), [
+        {
+          'content': 'Foo',
+          'isBlankLine': false,
+        }
+      ]);
+    });
+
+    test('a single line with a line ending', () {
+      const text = 'Foo\n';
+      final lines = text.toLines();
+
+      expect(lines.map((e) => e.toMap()), [
+        {
+          'content': 'Foo',
+          'isBlankLine': false,
+        },
+      ]);
+    });
+
+    test('multiple lines with a blank line in between', () {
+      const text = 'Foo\r\n\nBar';
+      final lines = text.toLines();
+
+      expect(lines.map((e) => e.toMap()), [
+        {
+          'content': 'Foo',
+          'isBlankLine': false,
+        },
+        {
+          'content': '',
+          'isBlankLine': true,
+        },
+        {
+          'content': 'Bar',
+          'isBlankLine': false,
+        }
+      ]);
+    });
+  });
+}

--- a/test/util_test.dart
+++ b/test/util_test.dart
@@ -54,7 +54,7 @@ void main() {
   });
 }
 
-extension LineX on Line {
+extension on Line {
   Map<String, dynamic> toMap() => {
         'content': content,
         'isBlankLine': isBlankLine,


### PR DESCRIPTION
The `Line` is used to maintain the `tabRemaining` for now.

This is a use case of `Line`, it can also explain the meaning of the `tabRemaining`:
https://spec.commonmark.org/0.30/#example-6

> Normally the `>` that begins a block quote may be followed optionally by a space, which is not considered part of the content. In the following case > is followed by a tab, which is treated as if it were expanded into three spaces. Since one of these spaces is considered part of the delimiter, foo is considered to be indented six spaces inside the block quote context, so we get an indented code block starting with two spaces.

In this example the `tabRemaining` is the two spaces from **blockquote** which will be used in the nested **indented code block**.

