### PR TITLE
Label tests that only run on the VM: allows running tests with browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 7.0.1-dev
+
 ## 7.0.0
 
 * **Breaking change**: `close()` of `DelimiterSyntax` and `LinkSyntax`

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '7.0.0';
+const packageVersion = '7.0.1-dev';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: markdown
-version: 7.0.0
+version: 7.0.1-dev
 
 description: >-
   A portable Markdown library written in Dart that can parse Markdown into HTML.

--- a/test/markdown_test.dart
+++ b/test/markdown_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@TestOn('vm')
+
 import 'package:markdown/markdown.dart';
 import 'package:test/test.dart';
 

--- a/test/version_test.dart
+++ b/test/version_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@TestOn('vm')
+
 import 'dart:io';
 
 import 'package:path/path.dart' as p;


### PR DESCRIPTION
Inspired by https://github.com/dart-lang/markdown/issues/515
