### PR TITLE
Remove lookarounds from autolink extension patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 7.0.1-dev
 
+* Remove RegExp lookarounds from autolink extension patterns.
+
 ## 7.0.0
 
 * **Breaking change**: `close()` of `DelimiterSyntax` and `LinkSyntax`

--- a/lib/src/inline_syntaxes/autolink_extension_syntax.dart
+++ b/lib/src/inline_syntaxes/autolink_extension_syntax.dart
@@ -43,7 +43,7 @@ class AutolinkExtensionSyntax extends InlineSyntax {
   // An extended email autolink, see
   // https://github.github.com/gfm/#extended-email-autolink.
   static const _emailPattern =
-      r'[-_.+a-z0-9]+@(?:[-_a-z0-9]+\.)+[-_a-z0-9]*[a-z0-9](?![-_])';
+      r'[-_.+a-z0-9]+@(?:[-_a-z0-9]+\.)+[-_a-z0-9]*[a-z0-9]';
 
   AutolinkExtensionSyntax()
       : super(
@@ -59,9 +59,19 @@ class AutolinkExtensionSyntax extends InlineSyntax {
       return false;
     }
 
-    if (parser.pos > 0) {
+    // When it is a link and it is not preceded by `*`, `_`, `~`, `(`, or `>`,
+    // it is invalid.
+    if (startMatch[1] != null && parser.pos > 0) {
       final precededBy = String.fromCharCode(parser.charAt(parser.pos - 1));
       if ([' ', '*', '_', '~', '(', '>'].contains(precededBy) == false) {
+        return false;
+      }
+    }
+
+    // When it is an email link and followed by `_` or `-`, it is invalid.
+    if (startMatch[2] != null && parser.source.length > startMatch.end) {
+      final followedBy = String.fromCharCode(parser.charAt(startMatch.end));
+      if (['_', '-'].contains(followedBy)) {
         return false;
       }
     }

--- a/lib/src/inline_syntaxes/autolink_extension_syntax.dart
+++ b/lib/src/inline_syntaxes/autolink_extension_syntax.dart
@@ -13,7 +13,8 @@ class AutolinkExtensionSyntax extends InlineSyntax {
   static const _linkPattern =
       // Autolinks can only come at the beginning of a line, after whitespace,
       // or any of the delimiting characters *, _, ~, and (.
-      // Note: Disable it, as Safari does not support lookarounds.
+      // Note: Disable this piece for now, as Safari does not support
+      // lookarounds. Consider re-enabling later.
       // r'(?<=^|[\s*_~(>])'
 
       // An extended url autolink will be recognised when one of the schemes
@@ -60,18 +61,22 @@ class AutolinkExtensionSyntax extends InlineSyntax {
     }
 
     // When it is a link and it is not preceded by `*`, `_`, `~`, `(`, or `>`,
-    // it is invalid.
+    // it is invalid. See
+    // https://github.github.com/gfm/#extended-autolink-path-validation.
     if (startMatch[1] != null && parser.pos > 0) {
       final precededBy = String.fromCharCode(parser.charAt(parser.pos - 1));
-      if ([' ', '*', '_', '~', '(', '>'].contains(precededBy) == false) {
+      const validPrecedingChars = {' ', '*', '_', '~', '(', '>'};
+      if (validPrecedingChars.contains(precededBy) == false) {
         return false;
       }
     }
 
-    // When it is an email link and followed by `_` or `-`, it is invalid.
+    // When it is an email link and followed by `_` or `-`, it is invalid. See
+    // https://github.github.com/gfm/#example-633
     if (startMatch[2] != null && parser.source.length > startMatch.end) {
       final followedBy = String.fromCharCode(parser.charAt(startMatch.end));
-      if (['_', '-'].contains(followedBy)) {
+      const invalidFollowingChars = {'_', '-'};
+      if (invalidFollowingChars.contains(followedBy)) {
         return false;
       }
     }

--- a/lib/src/inline_syntaxes/autolink_extension_syntax.dart
+++ b/lib/src/inline_syntaxes/autolink_extension_syntax.dart
@@ -13,7 +13,7 @@ class AutolinkExtensionSyntax extends InlineSyntax {
   static const _linkPattern =
       // Autolinks can only come at the beginning of a line, after whitespace,
       // or any of the delimiting characters *, _, ~, and (.
-      // Note: Disable it, as safari does not support lookarounds.
+      // Note: Disable it, as Safari does not support lookarounds.
       // r'(?<=^|[\s*_~(>])'
 
       // An extended url autolink will be recognised when one of the schemes
@@ -36,7 +36,7 @@ class AutolinkExtensionSyntax extends InlineSyntax {
       // not be considered part of the autolink, though they may be included in
       // the interior of the link. See
       // https://github.github.com/gfm/#extended-autolink-path-validation.
-      // Note: Do not use negative lookbehind, as safari does not support it.
+      // Note: Do not use negative lookbehind, as Safari does not support it.
       // '(?<![?!.,:*_~])'
       r'[^\s<?!.,:*_~]';
 

--- a/lib/src/inline_syntaxes/autolink_extension_syntax.dart
+++ b/lib/src/inline_syntaxes/autolink_extension_syntax.dart
@@ -13,7 +13,8 @@ class AutolinkExtensionSyntax extends InlineSyntax {
   static const _linkPattern =
       // Autolinks can only come at the beginning of a line, after whitespace,
       // or any of the delimiting characters *, _, ~, and (.
-      r'(?<=^|[\s*_~(>])'
+      // Note: Disable it, as safari does not support lookarounds.
+      // r'(?<=^|[\s*_~(>])'
 
       // An extended url autolink will be recognised when one of the schemes
       // http://, or https://, followed by a valid domain. See
@@ -35,7 +36,9 @@ class AutolinkExtensionSyntax extends InlineSyntax {
       // not be considered part of the autolink, though they may be included in
       // the interior of the link. See
       // https://github.github.com/gfm/#extended-autolink-path-validation.
-      '(?<![?!.,:*_~])';
+      // Note: Do not use negative lookbehind, as safari does not support it.
+      // '(?<![?!.,:*_~])'
+      r'[^\s<?!.,:*_~]';
 
   // An extended email autolink, see
   // https://github.github.com/gfm/#extended-email-autolink.
@@ -55,6 +58,14 @@ class AutolinkExtensionSyntax extends InlineSyntax {
     if (startMatch == null) {
       return false;
     }
+
+    if (parser.pos > 0) {
+      final precededBy = String.fromCharCode(parser.charAt(parser.pos - 1));
+      if ([' ', '*', '_', '~', '(', '>'].contains(precededBy) == false) {
+        return false;
+      }
+    }
+
     parser.writeText();
     return onMatch(parser, startMatch);
   }

--- a/test/extensions/autolink_extension.unit
+++ b/test/extensions/autolink_extension.unit
@@ -1,0 +1,4 @@
+>>> not a link 
+mhttp://www.foo.com
+<<<
+<p>mhttp://www.foo.com</p>

--- a/test/markdown_test.dart
+++ b/test/markdown_test.dart
@@ -41,6 +41,10 @@ void main() async {
     'extensions/unordered_list_with_checkboxes.unit',
     blockSyntaxes: [const UnorderedListWithCheckboxSyntax()],
   );
+  testFile(
+    'extensions/autolink_extension.unit',
+    inlineSyntaxes: [AutolinkExtensionSyntax()],
+  );
 
   // Inline syntax extensions
   testFile(


### PR DESCRIPTION
Fix: https://github.com/dart-lang/markdown/issues/515