### PR TITLE
Table should be able to interrupt other blocks

### DIFF
--- a/lib/src/block_syntaxes/table_syntax.dart
+++ b/lib/src/block_syntaxes/table_syntax.dart
@@ -11,7 +11,7 @@ import 'block_syntax.dart';
 /// Parses tables.
 class TableSyntax extends BlockSyntax {
   @override
-  bool canEndBlock(BlockParser parser) => false;
+  bool canEndBlock(BlockParser parser) => true;
 
   @override
   RegExp get pattern => dummyPattern;

--- a/test/extensions/tables.unit
+++ b/test/extensions/tables.unit
@@ -355,3 +355,24 @@ too | many | cells | here
 </tr>
 </tbody>
 </table>
+>>> can interrupt a paragraph
+paragraph
+foo | bar
+--- | ---
+baz | bim
+<<<
+<p>paragraph</p>
+<table>
+<thead>
+<tr>
+<th>foo</th>
+<th>bar</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>baz</td>
+<td>bim</td>
+</tr>
+</tbody>
+</table>


### PR DESCRIPTION
- Make table be able to interrupt other blocks, such as paragraph, fix: https://github.com/dart-lang/markdown/issues/543

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
