### PR TITLE
Fix HtmlBlockSyntax

### DIFF
--- a/lib/src/block_syntaxes/html_block_syntax.dart
+++ b/lib/src/block_syntaxes/html_block_syntax.dart
@@ -73,12 +73,9 @@ class HtmlBlockSyntax extends BlockSyntax {
       parser.advance();
     }
 
-    // If the following lines start an HTML block again, put them together with
-    // current HTML block.
-    if (!parser.isDone &&
-        parser.next != null &&
-        pattern.hasMatch(parser.next!.content)) {
-      parser.advance();
+    // If the current line start an HTML block again, put them together with
+    // the previous HTML block.
+    if (!parser.isDone && pattern.hasMatch(parser.current.content)) {
       lines.addAll(parseChildLines(parser));
     }
 

--- a/test/original/html_block.unit
+++ b/test/original/html_block.unit
@@ -1,0 +1,11 @@
+>>> issue https://github.com/dart-lang/markdown/issues/547
+<?code-excerpt ?>
+```xml
+<q>
+</q>
+```
+<<<
+<?code-excerpt ?>
+<pre><code class="language-xml">&lt;q&gt;
+&lt;/q&gt;
+</code></pre>


### PR DESCRIPTION
Fix an issue of `HtmlBlockSyntax`: https://github.com/dart-lang/markdown/issues/547