### PR TITLE
Fix beginning of line detection in `AutolinkExtensionSyntax`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 7.1.2-wip
 
 * Update all CommonMark specification links to 0.30.
+* Fix beginning of line detection in `AutolinkExtensionSyntax`. 
 
 ## 7.1.1
 

--- a/lib/src/inline_syntaxes/autolink_extension_syntax.dart
+++ b/lib/src/inline_syntaxes/autolink_extension_syntax.dart
@@ -60,12 +60,12 @@ class AutolinkExtensionSyntax extends InlineSyntax {
       return false;
     }
 
-    // When it is a link and it is not preceded by `*`, `_`, `~`, `(`, or `>`,
-    // it is invalid. See
-    // https://github.github.com/gfm/#extended-autolink-path-validation.
+    // When it is a link and it is not at the beginning of a line, or preceded
+    // by whitespace, `*`, `_`, `~`, `(`, or `>`, it is invalid. See
+    // https://github.github.com/gfm/#autolinks-extension-.
     if (startMatch[1] != null && parser.pos > 0) {
       final precededBy = String.fromCharCode(parser.charAt(parser.pos - 1));
-      const validPrecedingChars = {' ', '*', '_', '~', '(', '>'};
+      const validPrecedingChars = {'\n', ' ', '*', '_', '~', '(', '>'};
       if (!validPrecedingChars.contains(precededBy)) {
         return false;
       }

--- a/test/extensions/autolink_extension.unit
+++ b/test/extensions/autolink_extension.unit
@@ -2,3 +2,9 @@
 mhttp://www.foo.com
 <<<
 <p>mhttp://www.foo.com</p>
+>>> following a newline
+m
+http://www.foo.com
+<<<
+<p>m
+<a href="http://www.foo.com">http://www.foo.com</a></p>


### PR DESCRIPTION
The [autolink extension specification](https://github.github.com/gfm/#extended-autolink-path-validation) notes that autolinks can come at the beginning of a line. The current implementation does not consider a newline a valid preceding character. Possibly a regression from #519.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
