### PR TITLE
address a termination issue with GitHub alert syntax parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.2.1
+
+* Address a termination issue with GitHub alert syntax parsing.
+
 ## 7.2.0
 
 * Require Dart `^3.1.0`.

--- a/lib/src/block_syntaxes/alert_block_syntax.dart
+++ b/lib/src/block_syntaxes/alert_block_syntax.dart
@@ -25,9 +25,10 @@ class AlertBlockSyntax extends BlockSyntax {
         parser.lines.any((line) => _contentLineRegExp.hasMatch(line.content));
   }
 
-  // Whether this alert ends with a lazy continuation line.
-  // The definition of lazy continuation lines:
-  // https://spec.commonmark.org/0.30/#lazy-continuation-line
+  /// Whether this alert ends with a lazy continuation line.
+  ///
+  /// The definition of lazy continuation lines:
+  /// https://spec.commonmark.org/0.30/#lazy-continuation-line
   static bool _lazyContinuation = false;
   static final _contentLineRegExp = RegExp(r'>?\s?(.*)*');
 

--- a/lib/src/block_syntaxes/alert_block_syntax.dart
+++ b/lib/src/block_syntaxes/alert_block_syntax.dart
@@ -25,7 +25,7 @@ class AlertBlockSyntax extends BlockSyntax {
         parser.lines.any((line) => _contentLineRegExp.hasMatch(line.content));
   }
 
-  /// Whether this alert ends with a lazy continuation line.
+  // Whether this alert ends with a lazy continuation line.
   // The definition of lazy continuation lines:
   // https://spec.commonmark.org/0.30/#lazy-continuation-line
   static bool _lazyContinuation = false;
@@ -40,7 +40,9 @@ class AlertBlockSyntax extends BlockSyntax {
     while (!parser.isDone) {
       final strippedContent =
           parser.current.content.replaceFirst(RegExp(r'^\s*>?\s*'), '');
-      final match = _contentLineRegExp.firstMatch(strippedContent);
+      final match = strippedContent.isEmpty
+          ? null
+          : _contentLineRegExp.firstMatch(strippedContent);
       if (match != null) {
         childLines.add(Line(strippedContent));
         parser.advance();
@@ -100,7 +102,7 @@ class AlertBlockSyntax extends BlockSyntax {
     final titleText = typeTextMap[type]!;
     final titleElement = Element('p', [Text(titleText)])
       ..attributes['class'] = 'markdown-alert-title';
-    final elementClass = 'markdown-alert markdown-alert-${type.toLowerCase()}';
+    final elementClass = 'markdown-alert markdown-alert-$type';
     return Element('div', [titleElement, ...children])
       ..attributes['class'] = elementClass;
   }

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '7.2.0';
+const packageVersion = '7.2.1';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: markdown
-version: 7.2.0
+version: 7.2.1
 
 description: >-
   A portable Markdown library written in Dart that can parse Markdown into HTML.

--- a/test/extensions/alert_extension.unit
+++ b/test/extensions/alert_extension.unit
@@ -74,7 +74,7 @@ Test note alert x2.</p>
 <p>[!NOTE]
 Test blockquote.</p>
 </blockquote>
->>>nested blockquote
+>>> nested blockquote
 > [!NOTE]
 >> Test nested blockquote.
 <<<
@@ -84,7 +84,7 @@ Test blockquote.</p>
 <p>Test nested blockquote.</p>
 </blockquote>
 </div>
->>>escape brackets
+>>> escape brackets
 > \[!note\]
 > Test escape brackets.
 <<<
@@ -92,3 +92,40 @@ Test blockquote.</p>
 <p class="markdown-alert-title">Note</p>
 <p>Test escape brackets.</p>
 </div>
+>>> terminates properly
+> [!note]
+> A sample note.
+
+Additional markdown text.
+<<<
+<div class="markdown-alert markdown-alert-note">
+<p class="markdown-alert-title">Note</p>
+<p>A sample note.</p>
+</div>
+<p>Additional markdown text.</p>
+>>> supports multiple quoted lines
+> [!note]
+> A sample note
+> with two lines.
+
+Additional markdown text.
+<<<
+<div class="markdown-alert markdown-alert-note">
+<p class="markdown-alert-title">Note</p>
+<p>A sample note
+with two lines.</p>
+</div>
+<p>Additional markdown text.</p>
+>>> supports multiple lines
+> [!note]
+> A sample note
+  with two lines.
+
+Additional markdown text.
+<<<
+<div class="markdown-alert markdown-alert-note">
+<p class="markdown-alert-title">Note</p>
+<p>A sample note
+with two lines.</p>
+</div>
+<p>Additional markdown text.</p>


### PR DESCRIPTION
- address a termination issue with GitHub alert syntax parsing

When trying out the new alert syntax, it looks like the parsing never terminates - all the content after an alert is included in the alert.

cc @AlexV525

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
