### PR TITLE
Fix #578: list with checkbox mixed with empty lines

### DIFF
--- a/lib/src/block_syntaxes/list_syntax.dart
+++ b/lib/src/block_syntaxes/list_syntax.dart
@@ -214,6 +214,7 @@ abstract class ListSyntax extends BlockSyntax {
           indent = precedingWhitespaces + contentWhitespances;
         }
 
+        taskListItemState = null;
         var content = contentBlockStart != null && !isBlank
             ? parseTaskListItem(textParser.substring(contentBlockStart))
             : '';

--- a/test/extensions/ordered_list_with_checkboxes.unit
+++ b/test/extensions/ordered_list_with_checkboxes.unit
@@ -61,3 +61,19 @@
 </code></pre>
 </li>
 </ol>
+>>> checkbox with empty content
+1. [ ] one
+2.
+3. 
+4. four
+5. [ ] five
+6.
+<<<
+<ol class="contains-task-list">
+<li class="task-list-item"><input type="checkbox"></input>one</li>
+<li></li>
+<li></li>
+<li>four</li>
+<li class="task-list-item"><input type="checkbox"></input>five</li>
+<li></li>
+</ol>


### PR DESCRIPTION
`taskListItemState` shall be reset before calling `parseTaskListItem` when detecting a list pattern. O/W, it will generate a checkbox for an empty item.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
