### PR TITLE
Fix #586: encode image tag's src attribute

### DIFF
--- a/lib/src/inline_syntaxes/image_syntax.dart
+++ b/lib/src/inline_syntaxes/image_syntax.dart
@@ -24,7 +24,9 @@ class ImageSyntax extends LinkSyntax {
   }) {
     final element = Element.empty('img');
     final children = getChildren();
-    element.attributes['src'] = destination;
+    element.attributes['src'] = normalizeLinkDestination(
+      escapePunctuation(destination),
+    );
     element.attributes['alt'] = children.map((node) {
       // See https://spec.commonmark.org/0.30/#image-description.
       // An image description may contain links. Fetch text from the alt

--- a/test/original/inline_images.unit
+++ b/test/original/inline_images.unit
@@ -18,3 +18,8 @@
 
 <<<
 <p><img src="http://foo.com/foo.png" alt="alt" /></p>
+>>> XSS
+![Uh oh...]("onerror="alert('XSS'))
+
+<<<
+<p><img src="%22onerror=%22alert('XSS')" alt="Uh oh..." /></p>


### PR DESCRIPTION
Encode the image tag's src attribute

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
