### PR TITLE
fix a crash when parsing alert block syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
-## 7.2.2-wip
+## 7.2.2
 
+* Fix a crash parsing alert block syntax (#584).
+* Have alert block syntax support multiple paragraphs (#577).
 * Require Dart `^3.2.0`.
 
 ## 7.2.1

--- a/lib/src/block_syntaxes/alert_block_syntax.dart
+++ b/lib/src/block_syntaxes/alert_block_syntax.dart
@@ -39,9 +39,9 @@ class AlertBlockSyntax extends BlockSyntax {
     _lazyContinuation = false;
 
     while (!parser.isDone) {
-      final strippedContent =
-          parser.current.content.replaceFirst(RegExp(r'^\s*>?\s*'), '');
-      final match = strippedContent.isEmpty
+      final lineContent = parser.current.content.trimLeft();
+      final strippedContent = lineContent.replaceFirst(RegExp(r'^>?\s*'), '');
+      final match = strippedContent.isEmpty && !lineContent.startsWith('>')
           ? null
           : _contentLineRegExp.firstMatch(strippedContent);
       if (match != null) {
@@ -51,7 +51,7 @@ class AlertBlockSyntax extends BlockSyntax {
         continue;
       }
 
-      final lastLine = childLines.last;
+      final lastLine = childLines.isEmpty ? Line('') : childLines.last;
 
       // A paragraph continuation is OK. This is content that cannot be parsed
       // as any other syntax except Paragraph, and it doesn't match the bar in

--- a/lib/src/block_syntaxes/alert_block_syntax.dart
+++ b/lib/src/block_syntaxes/alert_block_syntax.dart
@@ -21,8 +21,7 @@ class AlertBlockSyntax extends BlockSyntax {
 
   @override
   bool canParse(BlockParser parser) {
-    return pattern.hasMatch(parser.current.content) &&
-        parser.lines.any((line) => _contentLineRegExp.hasMatch(line.content));
+    return alertPattern.hasMatch(parser.current.content);
   }
 
   /// Whether this alert ends with a lazy continuation line.

--- a/lib/src/patterns.dart
+++ b/lib/src/patterns.dart
@@ -153,9 +153,9 @@ final htmlCharactersPattern = RegExp(
 final linkReferenceDefinitionPattern = RegExp(r'^[ ]{0,3}\[');
 
 /// Alert type patterns.
-/// A alert block is similar to a blockquote,
-/// starts with `> [!TYPE]`, and only 5 types are supported
-/// with case-insensitive.
+///
+/// A alert block is similar to a blockquote, starts with `> [!TYPE]`, and only
+/// 5 types are supported (case-insensitive).
 final alertPattern = RegExp(
   r'^\s{0,3}>\s{0,3}\\?\[!(note|tip|important|caution|warning)\\?\]\s*$',
   caseSensitive: false,

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '7.2.2-wip';
+const packageVersion = '7.2.2';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,9 +1,9 @@
 name: markdown
-version: 7.2.2-wip
-
+version: 7.2.2
 description: >-
   A portable Markdown library written in Dart that can parse Markdown into HTML.
 repository: https://github.com/dart-lang/markdown
+
 topics:
  - markdown
 

--- a/test/extensions/alert_extension.unit
+++ b/test/extensions/alert_extension.unit
@@ -129,3 +129,34 @@ Additional markdown text.
 with two lines.</p>
 </div>
 <p>Additional markdown text.</p>
+>>> supports continuation lines
+> [!note]
+> A sample note
+with two lines.
+
+Additional markdown text.
+<<<
+<div class="markdown-alert markdown-alert-note">
+<p class="markdown-alert-title">Note</p>
+<p>A sample note
+with two lines.</p>
+</div>
+<p>Additional markdown text.</p>
+>>> crash repro #584.1
+> [!Warning]
+>
+> Some extensions won't work on dynamic types.
+<<<
+<div class="markdown-alert markdown-alert-warning">
+<p class="markdown-alert-title">Warning</p>
+<p>Some extensions won't work on dynamic types.</p>
+</div>
+>>> crash repro #584.2
+> [!NOTE]
+> 
+> if you receive the following error:
+<<<
+<div class="markdown-alert markdown-alert-note">
+<p class="markdown-alert-title">Note</p>
+<p>if you receive the following error:</p>
+</div>


### PR DESCRIPTION
- fix a crash when parsing alert block syntax (fix #584)
- have alert block syntax support multiple paragraphs (close #577)

@srawlins - this also revs the package version in preparation for publishing (so we can get the fix out for pub.dev).

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
