### PR TITLE
Add single tilde support to `StrikethroughSyntax`

### DIFF
--- a/lib/src/inline_syntaxes/strikethrough_syntax.dart
+++ b/lib/src/inline_syntaxes/strikethrough_syntax.dart
@@ -13,6 +13,6 @@ class StrikethroughSyntax extends DelimiterSyntax {
           requiresDelimiterRun: true,
           allowIntraWord: true,
           startCharacter: $tilde,
-          tags: [DelimiterTag('del', 2)],
+          tags: [DelimiterTag('del', 1), DelimiterTag('del', 2)],
         );
 }

--- a/test/gfm/strikethrough_extension.unit
+++ b/test/gfm/strikethrough_extension.unit
@@ -9,3 +9,11 @@ new paragraph~~.
 <<<
 <p>This ~~has a</p>
 <p>new paragraph~~.</p>
+>>> single tilde
+~Hi~ there.
+<<<
+<p><del>Hi</del> there.</p>
+>>> single tilde with double tilde
+~Hi~~ there.
+<<<
+<p><del>Hi</del>~ there.</p>


### PR DESCRIPTION
Fix: https://github.com/dart-lang/markdown/issues/592
