### PR TITLE
Link uri encoding, URL-escaping should be left alone inside the destination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 .pub
 pubspec.lock
 doc/
-.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .pub
 pubspec.lock
 doc/
+.idea/

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -53,15 +53,19 @@ String normalizeLinkDestination(String destination) {
 
   final regex = RegExp('%[0-9A-Fa-f]{2}');
   final matches = regex.allMatches(destination).toList();
-  final substrings = destination
-      .split(regex)
-      .map((e) => Uri.encodeFull(decodeHtmlCharacters(e)))
-      .toList();
+  final splitIterator = destination.split(regex).map((e) {
+    try {
+      e = Uri.decodeFull(e);
+    } catch (_) {}
+    return Uri.encodeFull(decodeHtmlCharacters(e));
+  }).iterator;
 
-  final buffer = StringBuffer(substrings[0]);
+  splitIterator.moveNext();
+  final buffer = StringBuffer(splitIterator.current);
   for (var i = 0; i < matches.length; i++) {
+    splitIterator.moveNext();
     buffer.write(matches[i].match);
-    buffer.write(substrings[i + 1]);
+    buffer.write(splitIterator.current);
   }
 
   return buffer.toString();

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -47,7 +47,7 @@ String normalizeLinkLabel(String label) {
 // https://spec.commonmark.org/0.30/#example-502
 String normalizeLinkDestination(String destination) {
   // Split by url escaping characters
-  // Concat them with unmodified URL-escaping.
+  // Concatenate them with unmodified URL-escaping.
   // URL-escaping should be left alone inside the destination
   // Refer: https://spec.commonmark.org/0.30/#example-502.
 

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -52,23 +52,17 @@ String normalizeLinkDestination(String destination) {
   // Refer: https://spec.commonmark.org/0.30/#example-502.
 
   final regex = RegExp('%[0-9A-Fa-f]{2}');
-  final matches = regex.allMatches(destination).toList();
-  final splitIterator = destination.split(regex).map((e) {
-    try {
-      e = Uri.decodeFull(e);
-    } catch (_) {}
-    return Uri.encodeFull(decodeHtmlCharacters(e));
-  }).iterator;
 
-  splitIterator.moveNext();
-  final buffer = StringBuffer(splitIterator.current);
-  for (var i = 0; i < matches.length; i++) {
-    splitIterator.moveNext();
-    buffer.write(matches[i].match);
-    buffer.write(splitIterator.current);
-  }
-
-  return buffer.toString();
+  return destination.splitMapJoin(
+    regex,
+    onMatch: (m) => m.match,
+    onNonMatch: (e) {
+      try {
+        e = Uri.decodeFull(e);
+      } catch (_) {}
+      return Uri.encodeFull(decodeHtmlCharacters(e));
+    },
+  );
 }
 
 /// Normalizes a link title, including the process of HTML characters decoding

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -41,17 +41,31 @@ String normalizeLinkLabel(String label) {
 }
 
 /// Normalizes a link destination, including the process of HTML characters
-/// decoding  and percent encoding.
+/// decoding and percent encoding.
 // See the description of these examples:
 // https://spec.commonmark.org/0.30/#example-501
 // https://spec.commonmark.org/0.30/#example-502
 String normalizeLinkDestination(String destination) {
-  // Decode first, because the destination might have been partly encoded.
-  // For example https://spec.commonmark.org/0.30/#example-502.
-  // With this function, `foo%20b&auml;` will be parsed in the following steps:
-  // 1. foo b&auml;
-  // 2. foo bä
-  // 3. foo%20b%C3%A4
+  // Split by url escaping characters
+  // Concat them with unmodified URL-escaping.
+  // URL-escaping should be left alone inside the destination
+  // Refer: https://spec.commonmark.org/0.30/#example-502.
+
+  final regex = RegExp('%[0-9A-Fa-f]{2}');
+  final matches = regex.allMatches(destination).toList();
+  final substrings = destination
+      .split(regex)
+      .map((e) => Uri.encodeFull(decodeHtmlCharacters(e)))
+      .toList();
+
+  final buffer = StringBuffer(substrings[0]);
+  for (var i = 0; i < matches.length; i++) {
+    buffer.write(matches[i].match);
+    buffer.write(substrings[i + 1]);
+  }
+
+  return buffer.toString();
+
   try {
     destination = Uri.decodeFull(destination);
   } catch (_) {}

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -65,11 +65,6 @@ String normalizeLinkDestination(String destination) {
   }
 
   return buffer.toString();
-
-  try {
-    destination = Uri.decodeFull(destination);
-  } catch (_) {}
-  return Uri.encodeFull(decodeHtmlCharacters(destination));
 }
 
 /// Normalizes a link title, including the process of HTML characters decoding

--- a/test/original/inline_images.unit
+++ b/test/original/inline_images.unit
@@ -23,7 +23,7 @@
 
 <<<
 <p><img src="%22onerror=%22alert('XSS')" alt="Uh oh..." /></p>
->>> image %2F shouldn't be encoded
+>>> URL-escaping should be left alone inside the destination
 ![](https://example/foo%2Fvar)
 <<<
 <p><img src="https://example/foo%2Fvar" alt="" /></p>

--- a/test/original/inline_images.unit
+++ b/test/original/inline_images.unit
@@ -23,3 +23,7 @@
 
 <<<
 <p><img src="%22onerror=%22alert('XSS')" alt="Uh oh..." /></p>
+>>> image %2F shouldn't be encoded
+![](https://example/foo%2Fvar)
+<<<
+<p><img src="https://example/foo%2Fvar" alt="" /></p>


### PR DESCRIPTION
Fix #597 

By the Commonmark Spec [URL-escaping should be left alone inside the destination](https://spec.commonmark.org/0.30/#example-502), reimplement `normalizeLinkDestination` util function with splitting by URL Escapings and concatenating them again.

We shouldn't use `decodeXXX` at initial string in any ways.

This doesn't make problem with fixed issue #589. All tests previous exist also are passed.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
