### PR TITLE
Add support for package:web 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 7.2.3
 
 * Fix an issue with checkbox list items separated with blank lines (#602).
+* Require package `web: '>=0.4.2 <2.0.0'`.
 
 ## 7.2.2
 

--- a/example/app.dart
+++ b/example/app.dart
@@ -69,7 +69,7 @@ void main() {
 void _renderMarkdown([Event? event]) {
   final markdown = markdownInput.value;
 
-  htmlDiv.innerHTML = md.markdownToHtml(markdown, extensionSet: extensionSet);
+  htmlDiv.innerHtml = md.markdownToHtml(markdown, extensionSet: extensionSet);
 
   for (final block in htmlDiv.querySelectorAll('pre code').items) {
     try {
@@ -138,4 +138,11 @@ extension on NamedNodeMap {
   void safeRemove(String qualifiedName) {
     if (getNamedItem(qualifiedName) != null) removeNamedItem(qualifiedName);
   }
+}
+
+extension on HTMLDivElement {
+  // The default implementation allows `JSAny` to support trusted types. We only
+  // use `String`s, so prefer this to avoid manual conversions.
+  @JS('innerHTML')
+  external set innerHtml(String value);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,5 +30,5 @@ dev_dependencies:
   pool: ^1.5.1
   tar: ^1.0.3
   test: ^1.16.0
-  web: '>=0.4.2 <0.6.0'
+  web: '>=0.4.2 <2.0.0'
   yaml: ^3.0.0


### PR DESCRIPTION
1.0.0 modifies innerHTML to be JSAny in order to support trusted types, and this is the only member that needs to be worked around to support that version.