### PR TITLE
Update `pub run` syntax and remove 404 images

### DIFF
--- a/benchmark/input.md
+++ b/benchmark/input.md
@@ -85,14 +85,9 @@ void main() {
 
 ## Running Tests
 
-A single test file can be run just using `pub run test:test path/to/test.dart`
-(on Dart 1.10, this can be shortened to `pub run test path/to/test.dart`).
+A single test file can be run just using `dart run test path/to/test.dart`.
 
-![Single file being run via pub run"](https://raw.githubusercontent.com/dart-lang/test/master/image/test1.gif)
-
-Many tests can be run at a time using `pub run test:test path/to/dir`.
-
-![Directory being run via "pub run".](https://raw.githubusercontent.com/dart-lang/test/master/image/test2.gif)
+Many tests can be run at a time using `dart run test path/to/dir`.
 
 It's also possible to run a test on the Dart VM only by invoking it using `dart
 path/to/test.dart`, but this doesn't load the full test runner and will be
@@ -103,11 +98,11 @@ file. If you don't pass any paths, it will run all the test files in your
 `test/` directory, making it easy to test your entire application at once.
 
 By default, tests are run in the Dart VM, but you can run them in the browser as
-well by passing `pub run test:test -p chrome path/to/test.dart`.
+well by passing `dart run test -p chrome path/to/test.dart`.
 `test` will take care of starting the browser and loading the tests, and all
 the results will be reported on the command line just like for VM tests. In
-fact, you can even run tests on both platforms with a single command: `pub run
-test:test -p "chrome,vm" path/to/test.dart`.
+fact, you can even run tests on both platforms with a single command: `dart run
+test -p chrome,vm path/to/test.dart`.
 
 ### Restricting Tests to Certain Platforms
 

--- a/test/version_test.dart
+++ b/test/version_test.dart
@@ -35,7 +35,7 @@ void main() {
       binVersion,
       pubspecContent['version'],
       reason: 'The version reported by bin/markdown.dart should match the '
-          'version in pubspec. Run `pub run build_runner build` to update.',
+          'version in pubspec. Run `dart run build_runner build` to update.',
     );
   });
 }


### PR DESCRIPTION
- Obsolete `pub run` syntax is used in some files. This was replaced with `dart run`.
  - `pub run test:test` was replaced with `dart run test`
- There were a couple rotten links for images demonstrating tests running. They were removed.

I think this PR is very minor and doesn't warrant opening an issue, version changes etc.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
